### PR TITLE
feat(worker): emit error event

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Worker
  - worker that also works with es6 modules
 
 
-As proof of concet, the goal is to make UI for jscad development that should be able to visualize the changes in realtime.
+As proof of concept, the goal is to make UI for jscad development that should be able to visualize the changes in realtime.
 
 - to feel responsive on script save, refresh of the preview under 50ms is desirable, but can be few times higher
 
@@ -31,7 +31,7 @@ As proof of concet, the goal is to make UI for jscad development that should be 
  - initial `async await` idea was abandoned as it complicates things greatly, and actual debugger in the browser can be used
    to pause the script and to step through the code. 
  - A second instance of jscad can be used to display any shapes needed to be seen while debugging (original instance can be frozen by debugger)
- - the debbuger instance of jscad can also be further enhanced to inspect the 3d model
+ - the debugger instance of jscad can also be further enhanced to inspect the 3d model
 
 ## allow fastest response 
 
@@ -46,10 +46,10 @@ As proof of concet, the goal is to make UI for jscad development that should be 
 
 - Use of TypedArrays where possible is preferred to allow for sending data between thread with no cost
 - it should be examined if regenerating model in the worker is fast enough, as sending TypedArray out removes access for the sender and coordinating who needs which data can be difficult.
-- consider a hybrid apporach of sending typed arrays data out, to be given back, or regenerated if needed in multiple places
+- consider a hybrid approach of sending typed arrays data out, to be given back, or regenerated if needed in multiple places
 - sets of boolean operations can be done in background
 - Making long running operations like booleans interruptible would be ideal.
-- calculating operation complexitiy in advance would be useful (based on precision that can affect the expected output size and ammount of calculation)
+- calculating operation complexity in advance would be useful (based on precision that can affect the expected output size and amount of calculation)
 
 
 ##  Allowing for changes to be localized instead of recalculating everything

--- a/apps/engine-test/README.md
+++ b/apps/engine-test/README.md
@@ -2,7 +2,7 @@
 
 you must install modules from root of the project because it uses workspaces
 
-go to root fodler of the project
+go to root folder of the project
 
 ```
 npm i

--- a/apps/engine-test/main.js
+++ b/apps/engine-test/main.js
@@ -195,7 +195,20 @@ const handlers = {
   entities: ({ entities }) => {
     if (!(entities instanceof Array)) entities = [entities]
     setViewerScene((model = entities))
+    setError(undefined)
   },
+  error: ({ error }) => setError(error)
+}
+
+function setError(error) {
+  const errorBar = byId('error-bar')
+  if (error) {
+    errorBar.style.display = "block"
+    const errorMessage = byId('error-message')
+    errorMessage.innerText = error
+  } else {
+    errorBar.style.display = "none"
+  }
 }
 
 const link = document.createElement('a')

--- a/apps/engine-test/static/index.html
+++ b/apps/engine-test/static/index.html
@@ -28,6 +28,9 @@
           <div class="boxInfo"><b><input type="checkbox" id="box_twgl_c"/><i></i></b></div>
         </div>
       </div>
+      <div id="error-bar">
+        <span id="error-message"></span>
+      </div>
     </div>
     <div id="dropModal">drop jscad script to execute it</div>
     <script type="module" src="/main.js"></script>

--- a/apps/engine-test/static/main.css
+++ b/apps/engine-test/static/main.css
@@ -171,3 +171,17 @@ jscadui-gizmo{
 
 jscadui-gizmo::part(face){
 }
+
+#error-bar {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  margin-left: -260px;
+  width: 520px;
+  background-color: #ee111199;
+  padding: 10px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  display: none;
+  font-family: monospace;
+}

--- a/packages/fs-provider/README.md
+++ b/packages/fs-provider/README.md
@@ -4,7 +4,7 @@ Provider that fills cache for `fs-service-worker` that you need in your main scr
 
 Use case is for creating a virtual folder that can be accessed by JavaScript during fetch or sync/async XMLHttpRequest. 
 
-## utilities for `RileReader`
+## utilities for `FileReader`
 
 [FileReader](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) is a bit old and does not use promises. It is a bit cumbersome to use. This is why in this library you have convenient `async` functions that you can use with `.then()` or `await`.
 

--- a/packages/worker/worker.js
+++ b/packages/worker/worker.js
@@ -49,21 +49,25 @@ export async function runMain({ params } = {}) {
   const transferable = []
 
   let time = Date.now()
-  solids = flatten(await main(params || {}))
-  // if (!(solids instanceof Array)){
-  //   solids = [solids]
-  // } else{
-  //   solids = flatten(solids)
-  // }
-  const solidsTime = Date.now() - time
+  try {
+    solids = flatten(await main(params || {}))
+    // if (!(solids instanceof Array)){
+    //   solids = [solids]
+    // } else{
+    //   solids = flatten(solids)
+    // }
+    const solidsTime = Date.now() - time
 
-  time = Date.now()
-  JscadToCommon.clearCache()
-  entities = JscadToCommon.prepare(solids, transferable, userInstances)
-  entities = entities.all
-//  entities = [...entities.lines, ...entities.line, ...entities.instance]
-  client.sendNotify('entities', { entities, solidsTime, entitiesTime: Date.now() - time }, transferable)
-  entities = [] // we lose access to bytearray data, it is transfered, and on our side it shows length=0
+    time = Date.now()
+    JscadToCommon.clearCache()
+    entities = JscadToCommon.prepare(solids, transferable, userInstances)
+    entities = entities.all
+  //  entities = [...entities.lines, ...entities.line, ...entities.instance]
+    client.sendNotify('entities', { entities, solidsTime, entitiesTime: Date.now() - time }, transferable)
+    entities = [] // we lose access to bytearray data, it is transfered, and on our side it shows length=0
+  } catch (error) {
+    client.sendNotify('error', { error })
+  }
 }
 
 // https://stackoverflow.com/questions/52086611/regex-for-matching-js-import-statements


### PR DESCRIPTION
This PR adds a try-catch around model generation in the worker. Any error thrown will be emitted as an "error" event using `client.sendNotify`.

I added a simple overlay div to the `engine-test` app to display model errors:

![error](https://github.com/hrgdavor/jscadui/assets/1766297/0f7d8ca0-7885-4c99-a044-a6df193066e1)

I also fixed some typos in the READMEs, sorry I couldn't help myself :laughing: 

Let me know what you think, or if you had a different idea for how to handle exceptions.