### PR TITLE
Updates to jscad-web

### DIFF
--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -212,9 +212,10 @@ const handlers = {
 function setError(error) {
   const errorBar = byId('error-bar')
   if (error) {
+    const message = error.toString().replace(/^Error: /, '')
     errorBar.style.display = "block"
     const errorMessage = byId('error-message')
-    errorMessage.innerText = error
+    errorMessage.innerText = message
   } else {
     errorBar.style.display = "none"
   }

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -322,19 +322,22 @@ const checkFiles = () => {
   requestAnimationFrame(checkFiles)
 }
 
+const spinner = byId('spinner')
 const paramChangeCallback = params => {
   console.log('params', params)
   sendCmd('runMain', { params })
 }
 const runScript = (script, url = './scripts.js') => {
+  spinner.style.display = 'block'
   sendCmd('runScript', { script, url }).then(result => {
-    console.log('result', result)
+    spinner.style.display = 'none'
     genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
   })
 }
 const runFile = file => {
+  spinner.style.display = 'block'
   sendCmd('runFile', { file }).then(result => {
-    console.log('result', result)
+    spinner.style.display = 'none'
     genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
   })
 }

--- a/apps/jscad-web/src/editor.js
+++ b/apps/jscad-web/src/editor.js
@@ -41,7 +41,16 @@ export const init = (compileFn) => {
       basicSetup,
       javascript(),
       keymap.of([
-        { key: "Shift-Enter", run: () => compileFn(view.state.doc.toString()), preventDefault: true },
+        {
+          key: "Shift-Enter",
+          run: () => compileFn(view.state.doc.toString()),
+          preventDefault: true
+        },
+        {
+          key: "Mod-s",
+          run: () => compileFn(view.state.doc.toString()),
+          preventDefault: true
+        },
         ...defaultKeymap
       ])
     ],

--- a/apps/jscad-web/static/index.html
+++ b/apps/jscad-web/static/index.html
@@ -15,6 +15,8 @@
             <div class="boxInfo"><b><input type="checkbox" id="box_three_c"/><i></i></b></div>
           </div>
         </div>
+
+        <div id="spinner" title="Processing..."></div>
       </div>
 
       <div id="editor" class="open">

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -417,6 +417,27 @@ p {
   font-size: 12pt;
 }
 
+#spinner {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  border: 6px solid #f3f3f3;
+  border-top: 6px solid #27c;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  animation: spin 1s linear infinite;
+  display: none;
+}
+.dark #spinner {
+  border: 6px solid #222;
+  border-top: 6px solid #16a;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
 #error-bar {
   position: absolute;
   bottom: 0;

--- a/packages/html-gizmo/index.js
+++ b/packages/html-gizmo/index.js
@@ -35,30 +35,27 @@ export class Gizmo extends HTMLElement {
 
     this.setNames(this.names)
 
-    first.onclick = e => {
+    first.addEventListener('click', (e) => {
       const cam = e.target.getAttribute('c')
       if (cam) this.oncam?.({ cam })
-    }
-
-    const doHoverClass = (el, over) => {
-      const classList = el.classList
-      if (over) classList.add('hover')
-      else classList.remove('hover')
-    }
+    })
 
     const mouseover = (el, over) => {
       const cam = el.getAttribute('c')
       if (cam) {
-        // select all camera links for the same camera (higliht corners)
+        // select all camera links for the same camera (highlight corners)
         const all = first.querySelectorAll(`[c="${cam}"]`)
-        all.forEach(el => doHoverClass(el, over))
+        all.forEach((el) => {
+          // toggle hover class
+          if (over) el.classList.add('hover')
+          else el.classList.remove('hover')
+        })
       }
     }
 
-    first.onmouseover = e => mouseover(e.target, true)
-
-    first.onmouseout = e => mouseover(e.target, false)
-    first.ondragstart = e => e.preventDefault()
+    first.addEventListener('pointerover', (e) => mouseover(e.target, true))
+    first.addEventListener('pointerout', (e) => mouseover(e.target, false))
+    first.addEventListener('dragstart', (e) => e.preventDefault())
   }
 
   setNames(_names=names){


### PR DESCRIPTION
Features:
 - Ctrl-S to update model (apple-S on mac)
 - Strip double "Error: " messages
 - Show spinner while generating geometry

Fix:
 - Gizmo use pointer-events instead of mouse-events to fix hover on mobile
