### PR TITLE
fix: module loading, and lots of error handling

### DIFF
--- a/apps/engine-test/main.js
+++ b/apps/engine-test/main.js
@@ -380,21 +380,25 @@ async function fileDropped(ev) {
 
   let pkgFile = await findFileInRoots(sw.roots, 'package.json')
   if (pkgFile) {
-    let pack = JSON.parse(await readAsText(pkgFile))
-    if (pack.main) fileToRun = pack.main
-    const alias = []
-    if (pack.workspaces)
-      for (let i = 0; i < pack.workspaces.length; i++) {
-        const w = pack.workspaces[i]
-        // debugger
-        let pack2 = await findFileInRoots(sw.roots, `/${w}/package.json`)
-        if (pack2) pack2 = JSON.parse(await readAsText(pack2))
-        let name = pack2?.name || w
-        let main = pack2?.main || 'index.js'
-        alias.push([`/${w}/${main}`, name])
+    try {
+      const pack = JSON.parse(await readAsText(pkgFile))
+      if (pack.main) fileToRun = pack.main
+      const alias = []
+      if (pack.workspaces)
+        for (let i = 0; i < pack.workspaces.length; i++) {
+          const w = pack.workspaces[i]
+          // debugger
+          let pack2 = await findFileInRoots(sw.roots, `/${w}/package.json`)
+          if (pack2) pack2 = JSON.parse(await readAsText(pack2))
+          let name = pack2?.name || w
+          let main = pack2?.main || 'index.js'
+          alias.push([`/${w}/${main}`, name])
+        }
+      if (alias.length) {
+        sendNotify('init', { alias })
       }
-    if (alias.length) {
-      sendNotify('init', { alias })
+    } catch (error) {
+      console.error('error parsing package.json', error)
     }
   }
 
@@ -407,8 +411,14 @@ async function fileDropped(ev) {
 
   if (fileToRun) {
     fileToRun = `/${fileToRun}`
-    runFile(fileToRun)
-    checkPrimary.push(await findFileInRoots(sw.roots, fileToRun))
+    const file = await findFileInRoots(sw.roots, fileToRun)
+    if (file) {
+      runFile(fileToRun)
+      checkPrimary.push(file)
+      editor.setSource(await readAsText(file))
+    } else {
+      setError(`main file not found ${fileToRun}`)
+    }
   }
 }
 

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -386,7 +386,7 @@ async function fileDropped(ev) {
   let pkgFile = await findFileInRoots(sw.roots, 'package.json')
   if (pkgFile) {
     try {
-      let pack = JSON.parse(await readAsText(pkgFile))
+      const pack = JSON.parse(await readAsText(pkgFile))
       if (pack.main) fileToRun = pack.main
       const alias = []
       if (pack.workspaces)

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -385,21 +385,25 @@ async function fileDropped(ev) {
 
   let pkgFile = await findFileInRoots(sw.roots, 'package.json')
   if (pkgFile) {
-    let pack = JSON.parse(await readAsText(pkgFile))
-    if (pack.main) fileToRun = pack.main
-    const alias = []
-    if (pack.workspaces)
-      for (let i = 0; i < pack.workspaces.length; i++) {
-        const w = pack.workspaces[i]
-        // debugger
-        let pack2 = await findFileInRoots(sw.roots, `/${w}/package.json`)
-        if (pack2) pack2 = JSON.parse(await readAsText(pack2))
-        let name = pack2?.name || w
-        let main = pack2?.main || 'index.js'
-        alias.push([`/${w}/${main}`, name])
+    try {
+      let pack = JSON.parse(await readAsText(pkgFile))
+      if (pack.main) fileToRun = pack.main
+      const alias = []
+      if (pack.workspaces)
+        for (let i = 0; i < pack.workspaces.length; i++) {
+          const w = pack.workspaces[i]
+          // debugger
+          let pack2 = await findFileInRoots(sw.roots, `/${w}/package.json`)
+          if (pack2) pack2 = JSON.parse(await readAsText(pack2))
+          let name = pack2?.name || w
+          let main = pack2?.main || 'index.js'
+          alias.push([`/${w}/${main}`, name])
+        }
+      if (alias.length) {
+        sendNotify('init', { alias })
       }
-    if (alias.length) {
-      sendNotify('init', { alias })
+    } catch (error) {
+      console.error('error parsing package.json', error)
     }
   }
 

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -327,7 +327,7 @@ const paramChangeCallback = params => {
   console.log('params', params)
   sendCmd('runMain', { params })
 }
-const runScript = (script, url = './scripts.js') => {
+const runScript = (script, url = './index.js') => {
   spinner.style.display = 'block'
   sendCmd('runScript', { script, url }).then(result => {
     spinner.style.display = 'none'
@@ -412,8 +412,14 @@ async function fileDropped(ev) {
 
   if (fileToRun) {
     fileToRun = `/${fileToRun}`
-    runFile(fileToRun)
-    checkPrimary.push(await findFileInRoots(sw.roots, fileToRun))
+    const file = await findFileInRoots(sw.roots, fileToRun)
+    if (file) {
+      runFile(fileToRun)
+      checkPrimary.push(file)
+      editor.setSource(await readAsText(file))
+    } else {
+      setError(`main file not found ${fileToRun}`)
+    }
   }
 }
 

--- a/apps/jscad-web/src/editor.js
+++ b/apps/jscad-web/src/editor.js
@@ -3,12 +3,12 @@ import { javascript } from "@codemirror/lang-javascript"
 import { defaultKeymap } from "@codemirror/commands"
 import { keymap } from "@codemirror/view"
 
-const initialCode = `const jscad = require("@jscad/modeling")
+const initialCode = `import * as jscad from '@jscad/modeling'
 const { intersect, subtract } = jscad.booleans
 const { colorize } = jscad.colors
 const { cube, sphere } = jscad.primitives
 
-const main = () => {
+export const main = () => {
   const outer = subtract(
     cube({ size: 10 }),
     sphere({ radius: 6.8 })
@@ -22,8 +22,6 @@ const main = () => {
     colorize([0.7, 0.7, 0.1], inner),
   ]
 }
-
-module.exports = { main }
 `
 
 let view

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -195,6 +195,8 @@ p {
   right: 10px;
   color: #bbb;
   white-space: nowrap;
+  font-size: 10pt;
+  user-select: none;
 }
 .dark #editor-hint {
   color: #888;
@@ -444,7 +446,7 @@ p {
   left: 50%;
   margin-left: -260px;
   width: 520px;
-  background-color: #ee111166;
+  background-color: #dd111199;
   padding: 10px;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
@@ -460,12 +462,12 @@ p {
   top: 10%;
   padding: 30px;
   border-radius: 10px;
-  background-color: rgba(240, 240, 240, 0.85);
+  background-color: rgba(240, 240, 240, 0.8);
   backdrop-filter: blur(10px);
   z-index: 4000;
 }
 .dark #welcome {
-  background-color: rgba(30, 30, 30, 0.85);
+  background-color: rgba(30, 30, 30, 0.8);
 }
 @media (min-width: 768px) {
   #welcome {

--- a/packages/format-jscad/index.js
+++ b/packages/format-jscad/index.js
@@ -168,6 +168,7 @@ JscadToCommon.prepare = (list, transferable, useInstances) => {
 
 export function JscadToCommon (csg, transferable, unique, options) {
   if (csg instanceof Array) return csg.map(csg2 => JscadToCommon(csg2, transferable, unique, options))
+  if (typeof csg !== 'object') throw new Error('invalid jscad geometry, not an object')
   let obj
 
   if (csg.polygons) obj = CSGCached(CSG2Vertices, csg, csg.polygons, transferable, unique, options)
@@ -188,7 +189,12 @@ export function JscadToCommon (csg, transferable, unique, options) {
   if(csg.color) obj.color = csg.color 
   if(csg.transforms) obj.transforms = csg.transforms
 
-  return obj || { csg, type: 'unknown' }
+  if (!obj || !obj.type) {
+    // throw new Error('invalid jscad geometry')
+    console.error('invalid jscad geometry', csg)
+    obj = { ...obj, csg, type: 'unknown' }
+  }
+  return obj
 }
 
 JscadToCommon.clearCache = () => {

--- a/packages/format-threejs/index.js
+++ b/packages/format-threejs/index.js
@@ -32,7 +32,10 @@ export function CommonToThree ({
     const objType = obj.type || 'mesh'
 
     const materialDef = materials[objType]
-    if (!materialDef) { console.error('material not found for type ', objType, obj) }
+    if (!materialDef) {
+      console.error(`material not found for type ${objType}`, obj)
+      return
+    }
     let material = materialDef.def
     const isInstanced = obj.type === 'instance'
     if ((color || colors) && !isInstanced) {

--- a/packages/render-threejs/index.js
+++ b/packages/render-threejs/index.js
@@ -198,7 +198,9 @@ export function RenderThreejs({
         if (obj3d) {
           entities.push(obj3d)
           group.add(obj3d)
-        } else console.error('could not conver to obj3d ', obj)
+        } else {
+          console.error('could not convert to obj3d', obj)
+        }
       })
       _scene.add(group)
     })

--- a/packages/require/src/readFileWeb.js
+++ b/packages/require/src/readFileWeb.js
@@ -2,14 +2,13 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data
 
 export const readFileWeb = (path, {base = '', output='text'})=>{
-  try {
-    const X = new XMLHttpRequest()
-    X.open('GET', base ? new URL(path, base) : path, 0) // sync
-    X.send()
-    if (X.status && X.status !== 200) throw new Error(X.statusText)
-    return X.responseText
-  } catch (e) {
-    console.error('problem reading file ', path, 'root', base, ' error:', e.message)
-    throw e
+  const req = new XMLHttpRequest()
+  req.open('GET', base ? new URL(path, base) : path, 0) // sync
+  req.send()
+  if (req.status && req.status === 404) {
+    throw new Error(`file not found ${path}`)
+  } else if (req.status && req.status !== 200) {
+    throw new Error(`failed to fetch file ${path} ${req.status} ${req.statusText}`)
   }
+  return req.responseText
 }

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -43,6 +43,7 @@ export const selfish = (func, context) => {
 export const resolveUrl = (url, base, root, moduleBase=MODULE_BASE)=>{
   let isRelativeFile = false
   let isModule = false
+  let cacheUrl = url
   
   if (!/^(http:|https:|fs:|file:)/.test(url)) {
     // npm modules cannot start with . or /
@@ -65,12 +66,13 @@ export const resolveUrl = (url, base, root, moduleBase=MODULE_BASE)=>{
       } else {
         url = url.substring(1)
       }
+      cacheUrl = `/${url}`
       // now create the full url to load the file
       url = new URL(url, root).toString()
     }
   }
   
-  return { url, isRelativeFile, isModule }
+  return { url, isRelativeFile, isModule, cacheUrl }
 }
 
 export function require(urlOrSource, transform, _readFile, _base, root, readModule, moduleBase = MODULE_BASE) {
@@ -100,8 +102,9 @@ export function require(urlOrSource, transform, _readFile, _base, root, readModu
     if(bundleAlias) _url = bundleAlias
   
     let resolved = resolveUrl(_url, base, root, moduleBase)
-    let {isModule} = resolved
+    const { isModule } = resolved
     url = resolved.url
+    cacheUrl = resolved.cacheUrl
     isRelativeFile = resolved.isRelativeFile
 
     if(isModule) readFile = readModule

--- a/packages/worker/worker.js
+++ b/packages/worker/worker.js
@@ -83,13 +83,17 @@ export const runFile = async ({ file }) => {
 const runScript = async ({ script, url, base=globalBase, root=globalBase }) => {
   console.log('{ script, url, base, root }', { script, url, base, root })
   const shouldTransform = url.endsWith('.ts') || script.includes('import') && (importReg.test(script) || exportReg.test(script))
-  const scriptModule = require({url,script}, shouldTransform ? transformFunc : undefined, readFileWeb, base, root, readFileWeb)
+  let def = []
 
-  const fromSource = getParameterDefinitionsFromSource(script)
-  const def = combineParameterDefinitions(fromSource, await scriptModule.getParameterDefinitions?.())
-
-  main = scriptModule.main
-  runMain({})
+  try {
+    const scriptModule = require({url,script}, shouldTransform ? transformFunc : undefined, readFileWeb, base, root, readFileWeb)
+    const fromSource = getParameterDefinitionsFromSource(script)
+    def = combineParameterDefinitions(fromSource, await scriptModule.getParameterDefinitions?.())
+    main = scriptModule.main
+    runMain({})
+  } catch (error) {
+    client.sendNotify('error', { error })
+  }
   return {def}
 }
 

--- a/packages/worker/worker.js
+++ b/packages/worker/worker.js
@@ -48,8 +48,10 @@ let entities = [],
 export async function runMain({ params } = {}) {
   const transferable = []
 
-  let time = Date.now()
   try {
+    if (!main) throw new Error('no main function exported')
+
+    let time = Date.now()
     solids = flatten(await main(params || {}))
     // if (!(solids instanceof Array)){
     //   solids = [solids]
@@ -66,6 +68,7 @@ export async function runMain({ params } = {}) {
     client.sendNotify('entities', { entities, solidsTime, entitiesTime: Date.now() - time }, transferable)
     entities = [] // we lose access to bytearray data, it is transfered, and on our side it shows length=0
   } catch (error) {
+    console.error(error)
     client.sendNotify('error', { error })
   }
 }
@@ -92,6 +95,7 @@ const runScript = async ({ script, url, base=globalBase, root=globalBase }) => {
     main = scriptModule.main
     runMain({})
   } catch (error) {
+    console.error(error)
     client.sendNotify('error', { error })
   }
   return {def}


### PR DESCRIPTION
This PR contains fixes to several packages:

 - handle errors thrown in `runScript`. this can happen when imports are not found.
 - handle errors in `require`. this can happen for missing npm packages.
 - fix relative path resolution. now I can drop multi-file projects and they work! this one took a lot of testing to get right.
 - handle invalid geometries. this one I noticed when I accidentally returned a function instead of jscad objects.
 - fix auto-reload for dependent files. previously it wasn't updating, due to cache key mismatch.

Basically I made a bunch of test files with: empty file, missing exports, various invalid imports, relative imports, nested folders, and anything silly I could think of. Fixed a ton of bugs, the loader code should be pretty robust now.