### PR TITLE
fix: send service worker errors back to caller

### DIFF
--- a/apps/engine-test/main.js
+++ b/apps/engine-test/main.js
@@ -197,7 +197,6 @@ const handlers = {
     setViewerScene((model = entities))
     setError(undefined)
   },
-  error: ({ error }) => setError(error)
 }
 
 function setError(error) {
@@ -279,6 +278,8 @@ registerServiceWorker('bundle.fs-serviceworker.js?prefix=/swfs/', async (path, s
   
   module.exports = { main }`
   runScript(script, './script.js')
+}).catch((error) => {
+  setError(error)
 })
 
 const findByFsPath = (arr, file) => {
@@ -338,12 +339,18 @@ const runScript = (script, url) => {
   sendCmd('runScript', { script, url }).then(result => {
     console.log('result', result)
     genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
+  }).catch((error) => {
+    spinner.style.display = 'none'
+    setError(error)
   })
 }
 const runFile = file => {
   sendCmd('runFile', { file }).then(result => {
     console.log('result', result)
     genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
+  }).catch((error) => {
+    spinner.style.display = 'none'
+    setError(error)
   })
 }
 
@@ -415,7 +422,6 @@ async function fileDropped(ev) {
     if (file) {
       runFile(fileToRun)
       checkPrimary.push(file)
-      editor.setSource(await readAsText(file))
     } else {
       setError(`main file not found ${fileToRun}`)
     }

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -206,7 +206,6 @@ const handlers = {
     setViewerScene((model = entities))
     setError(undefined)
   },
-  error: ({ error }) => setError(error)
 }
 
 function setError(error) {
@@ -271,6 +270,8 @@ registerServiceWorker('bundle.fs-serviceworker.js?prefix=/swfs/', async (path, s
     },
     baseURI: new URL(`/swfs/${sw.id}/`, document.baseURI).toString(),
   })
+}).catch((error) => {
+  setError(error)
 })
 
 const findByFsPath = (arr, file) => {
@@ -332,6 +333,9 @@ const runScript = (script, url = './index.js') => {
   sendCmd('runScript', { script, url }).then(result => {
     spinner.style.display = 'none'
     genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
+  }).catch((error) => {
+    spinner.style.display = 'none'
+    setError(error)
   })
 }
 const runFile = file => {
@@ -339,6 +343,9 @@ const runFile = file => {
   sendCmd('runFile', { file }).then(result => {
     spinner.style.display = 'none'
     genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
+  }).catch((error) => {
+    spinner.style.display = 'none'
+    setError(error)
   })
 }
 

--- a/packages/fs-provider/fs-provider.js
+++ b/packages/fs-provider/fs-provider.js
@@ -65,7 +65,12 @@ export const registerServiceWorker = async (workerScript, _getFile = getFile, { 
 
     // id is important as we use it to name the temporary cache instance
     // for now we use fetch to extract our id, but a better way could be found later
-    const id = await fetch(prefix + 'init').then(r => r.text())
+    const id = await fetch(prefix + 'init').then((res) => {
+      if (!res.ok) {
+        throw new Error('failed to start service worker')
+      }
+      return res.text()
+    })
     sw.id = id
     const cacheId = prefix + id
     window.addEventListener('beforeunload', e => caches.delete(cacheId))

--- a/packages/postmessage/README.md
+++ b/packages/postmessage/README.md
@@ -1,15 +1,15 @@
 # postMessage utility
 
-Allows for simpler usage of [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage) by defining a kinf od RPC protocol that can send notifications or call methods. Calling methods is handled with Promises because the postMessage is async by definition.
+Allows for simpler usage of [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage) by defining a kind of RPC protocol that can send notifications or call methods. Calling methods is handled with Promises because the postMessage is async by definition.
 
-If you use this utility in your main thread and in the worker, it will (in my opinion) simplify 
+If you use this utility in your main thread and in the worker, it will (in my opinion) simplify
 
 ## transferable
+
 It is simple to send transferable objects when sending a message to the worker by adding a parameter.
 
 It is however more tricky to support transferable for return values without complicating simple use
-cases thet do not need transferable.
+cases that do not need transferable.
 
-If you have a method that can be called and it needs to return transerable then you must use object as a return value.
-Whien returning such object, include `__transferable` key in the return value. It will not be in the data at the receiving end but will be taken out and passed to postMessage sa transferable paramter.
-
+If you have a method that can be called and it needs to return transferable then you must use object as a return value.
+When returning such object, include `__transferable` key in the return value. It will not be in the data at the receiving end but will be taken out and passed to postMessage as a transferable parameter.

--- a/packages/worker/worker.js
+++ b/packages/worker/worker.js
@@ -48,29 +48,24 @@ let entities = [],
 export async function runMain({ params } = {}) {
   const transferable = []
 
-  try {
-    if (!main) throw new Error('no main function exported')
+  if (!main) throw new Error('no main function exported')
 
-    let time = Date.now()
-    solids = flatten(await main(params || {}))
-    // if (!(solids instanceof Array)){
-    //   solids = [solids]
-    // } else{
-    //   solids = flatten(solids)
-    // }
-    const solidsTime = Date.now() - time
+  let time = Date.now()
+  solids = flatten(await main(params || {}))
+  // if (!(solids instanceof Array)) {
+  //   solids = [solids]
+  // } else {
+  //   solids = flatten(solids)
+  // }
+  const solidsTime = Date.now() - time
 
-    time = Date.now()
-    JscadToCommon.clearCache()
-    entities = JscadToCommon.prepare(solids, transferable, userInstances)
-    entities = entities.all
-  //  entities = [...entities.lines, ...entities.line, ...entities.instance]
-    client.sendNotify('entities', { entities, solidsTime, entitiesTime: Date.now() - time }, transferable)
-    entities = [] // we lose access to bytearray data, it is transfered, and on our side it shows length=0
-  } catch (error) {
-    console.error(error)
-    client.sendNotify('error', { error })
-  }
+  time = Date.now()
+  JscadToCommon.clearCache()
+  entities = JscadToCommon.prepare(solids, transferable, userInstances)
+  entities = entities.all
+  // entities = [...entities.lines, ...entities.line, ...entities.instance]
+  client.sendNotify('entities', { entities, solidsTime, entitiesTime: Date.now() - time }, transferable)
+  entities = [] // we lose access to bytearray data, it is transfered, and on our side it shows length=0
 }
 
 // https://stackoverflow.com/questions/52086611/regex-for-matching-js-import-statements
@@ -88,16 +83,11 @@ const runScript = async ({ script, url, base=globalBase, root=globalBase }) => {
   const shouldTransform = url.endsWith('.ts') || script.includes('import') && (importReg.test(script) || exportReg.test(script))
   let def = []
 
-  try {
-    const scriptModule = require({url,script}, shouldTransform ? transformFunc : undefined, readFileWeb, base, root, readFileWeb)
-    const fromSource = getParameterDefinitionsFromSource(script)
-    def = combineParameterDefinitions(fromSource, await scriptModule.getParameterDefinitions?.())
-    main = scriptModule.main
-    runMain({})
-  } catch (error) {
-    console.error(error)
-    client.sendNotify('error', { error })
-  }
+  const scriptModule = require({url,script}, shouldTransform ? transformFunc : undefined, readFileWeb, base, root, readFileWeb)
+  const fromSource = getParameterDefinitionsFromSource(script)
+  def = combineParameterDefinitions(fromSource, await scriptModule.getParameterDefinitions?.())
+  main = scriptModule.main
+  await runMain({})
   return {def}
 }
 


### PR DESCRIPTION
Add `sendError` method to `postmessage` to return errors thrown back to the caller.

This makes it so that any error thrown in a `postmessage` command will be automatically returned to the caller as part of the promise. This makes error handling more simple, and more likely to catch unforeseen errors. I was able to remove some `try` clauses, because the errors will be caught and sent back to the main thread automatically now.

I did this work as I was trying to track down a bug where sometimes `/swfs/init` returns 404, resulting in `sw.id` not being set correctly. This commit does not actually fix the service worker issue, but at least raises the error to the user when it happens:

![sw-failed](https://github.com/hrgdavor/jscadui/assets/1766297/7402ee41-c666-49d0-a106-46b6690b461d)
