### PR TITLE
jscad-web minor updates

### DIFF
--- a/apps/engine-test/main.js
+++ b/apps/engine-test/main.js
@@ -22,7 +22,7 @@ import {
   readAsText,
   readDir,
   registerServiceWorker,
-} from '../../packages/fs-provider/fs-provider'
+} from '@jscadui/fs-provider'
 import { availableEngines, availableEnginesList } from './src/availableEngines'
 import { CurrentUrl } from './src/currentUrl'
 import { EngineState } from './src/engineState'

--- a/apps/engine-test/main.js
+++ b/apps/engine-test/main.js
@@ -151,24 +151,6 @@ sel.oninput = e => {
   setViewerScene(model)
 }
 
-let checkChange_timer
-let fileToWatch
-let lastModified
-
-function checkChange() {
-  if (!fileToWatch) return
-
-  clearTimeout(checkChange_timer)
-  fileToWatch.file(f => {
-    if (f.lastModified != lastModified) {
-      initScript(f)
-      lastModified = f.lastModified
-      console.log('lastModified::', f.lastModified, f)
-    }
-  })
-  checkChange_timer = setTimeout(checkChange, 300)
-}
-
 const dropModal = byId('dropModal')
 const showDrop = show => {
   clearTimeout(showDrop.timer)

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -95,24 +95,6 @@ const doAnim = () => {
 let animDuration = 200
 let animTimer, stateStart, stateEnd, startTime
 
-let checkChange_timer
-let fileToWatch
-let lastModified
-
-function checkChange() {
-  if (!fileToWatch) return
-
-  clearTimeout(checkChange_timer)
-  fileToWatch.file(f => {
-    if (f.lastModified != lastModified) {
-      initScript(f)
-      lastModified = f.lastModified
-      console.log('lastModified::', f.lastModified, f)
-    }
-  })
-  checkChange_timer = setTimeout(checkChange, 300)
-}
-
 const dropModal = byId('dropModal')
 const showDrop = show => {
   clearTimeout(showDrop.timer)

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -143,15 +143,15 @@ const handlers = {
   },
 }
 
-function setError(error) {
+const setError = (error) => {
   const errorBar = byId('error-bar')
   if (error) {
     const message = error.toString().replace(/^Error: /, '')
-    errorBar.style.display = "block"
     const errorMessage = byId('error-message')
     errorMessage.innerText = message
+    errorBar.classList.add('visible')
   } else {
-    errorBar.style.display = "none"
+    errorBar.classList.remove('visible')
   }
 }
 

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -18,7 +18,7 @@ import {
   readDir,
   registerServiceWorker,
 } from '../../packages/fs-provider/fs-provider'
-import { EngineState } from './src/engineState.js'
+import { ViewState } from './src/viewState.js'
 import * as engine from './src/engine.js'
 
 import * as editor from "./src/editor.js"
@@ -29,7 +29,7 @@ import * as exporter from "./src/exporter.js"
 export const byId = id => document.getElementById(id)
 customElements.define('jscadui-gizmo', Gizmo)
 
-const engineState = new EngineState()
+const viewState = new ViewState()
 
 const gizmo = (window.gizmo = new Gizmo())
 byId('layout').appendChild(gizmo)
@@ -40,11 +40,11 @@ model = model.map(m => JscadToCommon(m))
 const elements = [byId('viewer')]
 
 function setViewerScene(model) {
-  engineState.setModel(model)
+  viewState.setModel(model)
 }
-const ctrl = (window.ctrl = new OrbitControl(elements, { ...engineState.camera, alwaysRotate: false }))
+const ctrl = (window.ctrl = new OrbitControl(elements, { ...viewState.camera, alwaysRotate: false }))
 function setViewerCamera({ position, target, rx, rz }) {
-  engineState.setCamera({ position, target })
+  viewState.setCamera({ position, target })
   gizmo.rotateXZ(rx, rz)
 }
 
@@ -56,7 +56,7 @@ const updateFromCtrl = change => {
 updateFromCtrl(ctrl)
 
 ctrl.onchange = change => {
-  engineState.saveCamera(change)
+  viewState.saveCamera(change)
   stopAnim()
   updateFromCtrl(change)
 }
@@ -64,7 +64,7 @@ ctrl.onchange = change => {
 gizmo.oncam = ({ cam }) => {
   const [rx, rz] = getCommonRotCombined(cam)
   startAnim({ rx, rz, target: [0, 0, 0] })
-  engineState.saveCamera(stateEnd)
+  viewState.saveCamera(stateEnd)
   //  ctrl.setCommonCamera(cam)
 }
 
@@ -353,7 +353,7 @@ const loadExample = (source) => {
 
 // Initialize three engine
 engine.init().then((viewer) => {
-  engineState.setEngine(viewer)
+  viewState.setEngine(viewer)
   setViewerScene(model)
 })
 

--- a/apps/jscad-web/src/viewState.js
+++ b/apps/jscad-web/src/viewState.js
@@ -4,7 +4,7 @@ import { themes } from './themes.js'
 
 const byId = (id) => document.getElementById(id)
 
-export class EngineState {
+export class ViewState {
   viewer = undefined
 
   constructor() {

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -445,6 +445,7 @@ p {
 
 #error-bar {
   position: absolute;
+  max-height: 40%;
   bottom: 0;
   left: 50%;
   margin-left: -260px;
@@ -455,6 +456,10 @@ p {
   border-top-right-radius: 10px;
   display: none;
   font-family: monospace;
+  overflow-y: auto;
+}
+#error-bar.visible {
+  display: block;
 }
 #error-bar label {
   font-weight: bold;


### PR DESCRIPTION
Nothing too major here:

 - add scroll bar to error panel
 - rename EngineState to ViewState
 - Unify `checkPrimary` and `checkSecondary` into just `filesToCheck`. This is a first step toward refactoring that code out of main. If there's a reason to have the primary/secondary be seperate, I couldn't see it.
 - Fix import of `@jscadui/fs-provider`
 - Remove old unused file check

Note: I got your commits @hrgdavor, and then rebased. FYI, I've been deleting the branch `jscad-web` in between PRs in order to avoid merge commits. You should probably delete your local branch before the next time you pull.