### PR TITLE
fixed 3mf hierarchy export

### DIFF
--- a/file-format/3mf-export/index.js
+++ b/file-format/3mf-export/index.js
@@ -1,42 +1,57 @@
-// this implementation exports to 3mf by filling array of strings and doing join at the encoding
-// tests for large files have shown significant speedup related to using string concatenation
-import { makeItem } from './src/makeItem.js'
-import { pushHeader } from './src/pushHeader.js'
-import { pushObjectWithComponents } from './src/pushObjectComponent.js'
-import { pushObjectWithMesh } from './src/pushObjectMesh.js'
+// this implementation exports to 3mf by filling array of strings and doing join
+// at the encoding tests for large files have shown significant speedup related
+// to using string concatenation
+import {makeItem} from './src/makeItem.js'
+import {pushHeader} from './src/pushHeader.js'
+import {pushObjectWithComponents} from './src/pushObjectComponent.js'
+import {pushObjectWithMesh} from './src/pushObjectMesh.js'
 
 export * from './src/staticFiles.js'
 
 
-export function to3dmodel({ simple = [], meshes = [], components = [], ...header }) {
+export function to3dmodel({
+  simple = [],
+  meshes = [],
+  components = [],
+  items = [],
+  precision = 17,
+  header
+}) {
   // items to be placed on the scene (build section of 3mf)
-  let items = []
-  let out = []
+  const out = []
 
   // <model> tag is opened here
   pushHeader(out, header)
-  
-  //#region resources
+
+  // #region resources
   out.push('  <resources>\n')
 
-  simple.forEach(({ id, vertices, indices, transforms }) => {
+  simple.forEach(({ id, vertices, indices, transform }) => {
     pushObjectWithMesh(out, id, vertices, indices)
-    items.push(makeItem(id, transforms))
+    items.push({objectID:id, transform})
   })
-  
-  meshes.forEach(({ id, vertices, indices, transforms }) => pushObjectWithMesh(out, id, vertices, indices))
 
-  components.forEach(({ id, items, transforms }) => {
-    pushObjectWithComponents(id, items)
-    items.push(makeItem(id, transforms))
-  })
+  if (items.length == 0) {
+    console.error('3MF empty build! Include items or simple.')
+  }
+
+  meshes.forEach(
+      ({id, vertices, indices, name}) =>
+          pushObjectWithMesh(out, id, vertices, indices, precision, name))
+
+  components.forEach(
+      ({id, children, name}) => {
+          pushObjectWithComponents(out, id, children, name)})
 
   out.push('  </resources>\n')
-  //#endregion
+  // #endregion
 
-  out.push(`<build>\n`, ...items, '</build>\n')
-  
-  out.push('</model>\n')// model tag was opened in the pushHeader()
+  out.push(`<build>\n`)
+  items.forEach(
+      ({objectID, transform}) => {out.push(makeItem(objectID, transform))})
+  out.push('</build>\n')
+
+  out.push('</model>\n')  // model tag was opened in the pushHeader()
 
   return out.join('')
 }

--- a/file-format/3mf-export/src/pushObjectComponent.js
+++ b/file-format/3mf-export/src/pushObjectComponent.js
@@ -1,14 +1,17 @@
-export function pushObjectWithComponents(out, id, items){
-  
-    out.push(`<object id="${id}" type="model">\n`)
-    out.push(` <components>\n`)
-    items.forEach(part => {
-        addComp(out, part.id, part.transforms)
-    })
-    out.push(` </components>\n`)
-    out.push(`</object>\n`)
-  }
+import {defMatrix} from './defMatrix.js'
+import {matrix2str} from './matrix2str.js'
 
-  const addComp = (out, id = 0, matrix = defMatrix) => {
-    out.push(`    <component objectid="${id}" transform="${matrix2str(matrix)}" />\n`)
-  }
+export function pushObjectWithComponents(out, id, children, name) {
+  out.push(`<object id="${id}" type="model"${
+      name == null ? '' : ' name="' + name + '"'}>\n`)
+  out.push(` <components>\n`)
+  children.forEach(
+      ({objectID, transform}) => {addComp(out, objectID, transform)})
+  out.push(` </components>\n`)
+  out.push(`</object>\n`)
+}
+
+const addComp = (out, id = 0, matrix = defMatrix) => {
+  out.push(
+      `    <component objectid="${id}" transform="${matrix2str(matrix)}" />\n`)
+}

--- a/file-format/3mf-export/src/pushObjectMesh.js
+++ b/file-format/3mf-export/src/pushObjectMesh.js
@@ -1,38 +1,37 @@
 /**
- * 
+ *
  * @param out {Arrray<string>}
- * @param obj 
- * @returns 
+ * @param obj
+ * @returns
  */
-export function pushObjectWithMesh(out,id, vertices, indices){
-    out.push(
-`  <object id="${id}" type="model">
+export function pushObjectWithMesh(
+    out, id, vertices, indices, precision, name) {
+  out.push(`  <object id="${id}" type="model"${
+      name == null ? '' : ' name="' + name + '"'}>
    <mesh>
     <vertices>
-`
-    )
+`)
 
-    for(let i=0; i<vertices.length; i+=3){
-        out.push(`     <vertex x="${vertices[i]}" y="${vertices[i+1]}" z="${vertices[i+2]}" />\n`)
-    }
+  for (let i = 0; i < vertices.length; i += 3) {
+    out.push(`     <vertex x="${vertices[i].toPrecision(precision)}" y="${
+        vertices[i + 1].toPrecision(
+            precision)}" z="${vertices[i + 2].toPrecision(precision)}" />\n`)
+  }
 
-    out.push(
-`    </vertices>
+  out.push(`    </vertices>
     <triangles>
-`
-    )
+`)
 
-    for(let i=0; i<indices.length; i+=3){
-        out.push(`     <triangle v1="${indices[i]}" v2="${indices[i+1]}" v3="${indices[i+2]}" />\n`)
-    }
+  for (let i = 0; i < indices.length; i += 3) {
+    out.push(`     <triangle v1="${indices[i]}" v2="${indices[i + 1]}" v3="${
+        indices[i + 2]}" />\n`)
+  }
 
 
-    out.push(
-`    </triangles>
+  out.push(`    </triangles>
    </mesh>
   </object>
-`
-    )
+`)
 
-    return out
+  return out
 }


### PR DESCRIPTION
Since I'm introducing a couple of breaking API changes anyway, I took the liberty of renaming a few things to reduce confusion (hopefully). `transforms -> transform` (since there's only one), `items -> children` since there is now a dedicated input called `items` which correspond to 3MF items. These allow one to define the roots of the component trees (before, the branches were all getting duplicated). I also added an optional precision parameter - it cut the file size by ~30% setting it to 7 instead of the default (since manifold uses float precision). I doubt there are many 3D printers that can really make use of double precision...

I've tested this in ManifoldCAD.org with corresponding changes to export our scene hierarchy and it's working well. My auto-format doesn't match the code that was here before very well - is that okay?