### PR TITLE
refactor: split out resizable drawer

### DIFF
--- a/apps/jscad-web/examples/hulls.example.js
+++ b/apps/jscad-web/examples/hulls.example.js
@@ -13,9 +13,14 @@ const { circle, cuboid, rectangle, sphere } = jscad.primitives
 const { translate } = jscad.transforms
 const { hull, hullChain } = jscad.hulls
 
-const getParameterDefinitions = () => [
-  { name: 'doHull', type: 'radio', caption: 'Show:', values: ['shapes', 'hull', 'chain'], captions: ['Original Shapes', 'Hull', 'Hull Chain'], initial: 'shapes' }
-]
+const getParameterDefinitions = () => [{
+    name: 'doHull',
+    type: 'radio',
+    caption: 'Hull type:',
+    values: ['shapes', 'hull', 'chain'],
+    captions: ['Original Shapes', 'Hull', 'Hull Chain'],
+    initial: 'shapes'
+}]
 
 const main = (params) => {
   const shapes2d = [

--- a/apps/jscad-web/examples/slicer.example.js
+++ b/apps/jscad-web/examples/slicer.example.js
@@ -1,0 +1,39 @@
+import * as jscad from '@jscad/modeling'
+const { colorize } = jscad.colors
+const { intersect } = jscad.booleans
+const { extrudeLinear, project } = jscad.extrusions
+const { measureBoundingBox } = jscad.measurements
+const { cuboid, sphere } = jscad.primitives
+const { translate } = jscad.transforms
+
+const thicness = 0.5
+
+export const main = () => {
+  const obj = sphere({ radius: 5 })
+
+  // calculate bounding box
+  const bbox = measureBoundingBox(obj)
+
+  // slice obj into an array of slices
+  const out = []
+  // from min z to max z
+  for (let z = bbox[0][2]; z < bbox[1][2]; z += thicness) {
+    // intersect with a cuboid
+    const cutter = cuboid({
+      size: [100, 100, thicness],
+      center: [0, 0, z]
+    })
+    const cut = intersect(obj, cutter)
+
+    // project the cut into a 2D shape
+    if (cut.polygons.length === 0) continue // not needed in V3
+    const projected = project({}, cut)
+
+    // extrude back to 3D
+    const extruded = extrudeLinear({ height: thicness }, projected)
+    const translated = translate([0, 0, z], extruded)
+    out.push(translated)
+  }
+
+  return colorize([0.7, 0, 0.1], out)
+}

--- a/apps/jscad-web/src/drawer.js
+++ b/apps/jscad-web/src/drawer.js
@@ -9,6 +9,12 @@ export const init = () => {
   // Initialize drawer action
   const editor = document.getElementById("editor")
   const toggle = document.getElementById("editor-toggle")
+  setEditorWidth(localStorage.getItem('editor.width') || 400)
+
+  function setEditorWidth(w){
+    if(w) editor.style.width = `${w}px`
+  }
+
   toggle.addEventListener("click", () => {
     if (!isDragging) {
       editor.classList.toggle("closed")
@@ -34,7 +40,8 @@ export const init = () => {
         const width = dragStartWidth - delta
         // Handle open/closed state
         if (width > 0) {
-          editor.style.width = `${width}px`
+          setEditorWidth(width)
+          localStorage.setItem('editor.width', width)
           editor.classList.remove("closed")
         } else {
           editor.style.width = ''

--- a/apps/jscad-web/src/drawer.js
+++ b/apps/jscad-web/src/drawer.js
@@ -1,0 +1,63 @@
+
+let isMouseDown = false
+let isDragging = false
+let dragStartX
+let dragStartWidth
+let dragStartTime
+
+export const init = () => {
+  // Initialize drawer action
+  const editor = document.getElementById("editor")
+  const toggle = document.getElementById("editor-toggle")
+  toggle.addEventListener("click", () => {
+    if (!isDragging) {
+      editor.classList.toggle("closed")
+    }
+  })
+
+  toggle.addEventListener('mousedown', (e) => {
+    isMouseDown = true
+    isDragging = false
+    dragStartX = e.clientX
+    dragStartWidth = editor.offsetWidth
+    dragStartTime = new Date()
+    e.preventDefault()
+  })
+
+  window.addEventListener('mousemove', (e) => {
+    if (isMouseDown) {
+      const delta = e.clientX - dragStartX
+      // Moved more than 5 pixels, assume dragging
+      if (isDragging || Math.abs(delta) > 5) {
+        isDragging = true
+        editor.classList.add("dragging") // prevent animation
+        const width = dragStartWidth - delta
+        // Handle open/closed state
+        if (width > 0) {
+          editor.style.width = `${width}px`
+          editor.classList.remove("closed")
+        } else {
+          editor.style.width = ''
+          editor.classList.add("closed")
+        }
+      }
+    }
+  })
+
+  window.addEventListener('mouseup', (e) => {
+    const downTime = new Date() - dragStartTime
+    // Long press, assume dragging
+    if (isDragging || downTime > 200) {
+      // Prevent click
+      isDragging = true
+    }
+    editor.classList.remove("dragging")
+    isMouseDown = false
+  })
+
+  // Close drawer on mobile
+  if (window.innerWidth < 768) {
+    // "dragging" to prevent animation
+    editor.classList.add("closed", "dragging")
+  }
+}

--- a/apps/jscad-web/src/editor.js
+++ b/apps/jscad-web/src/editor.js
@@ -2,13 +2,9 @@ import { EditorView, basicSetup } from "codemirror"
 import { javascript } from "@codemirror/lang-javascript"
 import { defaultKeymap } from "@codemirror/commands"
 import { keymap } from "@codemirror/view"
+import * as drawer from './drawer.js'
 
 let view
-let isMouseDown = false
-let isDragging = false
-let dragStartX
-let dragStartWidth
-let dragStartTime
 
 let compileFn
 
@@ -47,69 +43,9 @@ export const init = (defaultCode, fn) => {
   setSource(defaultCode)
 
   // Initialize drawer action
-  const editor = document.getElementById("editor")
-  const toggle = document.getElementById("editor-toggle")
-  toggle.addEventListener("click", () => {
-    if (!isDragging) {
-      editor.classList.toggle("closed")
-    }
-  })
-
-  toggle.addEventListener('mousedown', (e) => {
-    isMouseDown = true
-    isDragging = false
-    dragStartX = e.clientX
-    dragStartWidth = editor.offsetWidth
-    dragStartTime = new Date()
-    e.preventDefault()
-  })
-
-  window.addEventListener('mousemove', (e) => {
-    if (isMouseDown) {
-      const delta = e.clientX - dragStartX
-      // Moved more than 5 pixels, assume dragging
-      if (isDragging || Math.abs(delta) > 5) {
-        isDragging = true
-        editor.classList.add("dragging") // prevent animation
-        const width = dragStartWidth - delta
-        // Handle open/closed state
-        if (width > 0) {
-          editor.style.width = `${width}px`
-          editor.classList.remove("closed")
-        } else {
-          editor.style.width = ''
-          editor.classList.add("closed")
-        }
-      }
-    }
-  })
-
-  window.addEventListener('mouseup', (e) => {
-    const downTime = new Date() - dragStartTime
-    // Long press, assume dragging
-    if (isDragging || downTime > 200) {
-      // Prevent click
-      isDragging = true
-    }
-    editor.classList.remove("dragging")
-    isMouseDown = false
-  })
-
-  // Close drawer on mobile
-  if (window.innerWidth < 768) {
-    // "dragging" to prevent animation
-    editor.classList.add("closed", "dragging")
-  }
+  drawer.init()
 }
 
 export const setSource = (source) => {
   view.dispatch({changes: {from: 0, to: view.state.doc.length, insert: source}})
-}
-
-/**
- * Set the compile function to call on shift-enter
- */
-export const setCompileFun = (fn) => {
-  
-  compile(view.state.doc.toString())
 }

--- a/apps/jscad-web/src/examples.js
+++ b/apps/jscad-web/src/examples.js
@@ -6,5 +6,6 @@ export const examples = [
   { name: 'Parametric Gear', source: './examples/gear.example.js' },
   { name: 'Nuts and Bolts', source: './examples/nuts-and-bolts.example.js' },
   { name: 'Text Shapes', source: './examples/text.example.js' },
+  { name: 'Slicer', source: './examples/slicer.example.js' },
   { name: 'Balloons', source: './examples/balloons.example.js' },
 ]

--- a/apps/jscad-web/static/index.html
+++ b/apps/jscad-web/static/index.html
@@ -75,6 +75,7 @@
         <ul>
           <li><a href="/docs/tutorial-01_gettingStarted.html" target="_blank">Getting Started</a></li>
           <li><a href="/docs/" target="_blank">API Reference</a></li>
+          <li><a href="https://github.com/jscad/OpenJSCAD.org" target="_blank">GitHub</a></li>
         </ul>
       </div>
 

--- a/apps/jscad-web/static/index.html
+++ b/apps/jscad-web/static/index.html
@@ -11,6 +11,26 @@
   </head>
   <body>
     <div class="container">
+      <div id="welcome">
+        <h1>JSCAD</h1>
+        <p>
+          JSCAD is a tool for creating parametric 2D and 3D CAD designs using JavaScript code.
+        </p>
+        <p>
+          Code CAD offers more precise control over designs, enables parameterized customization of models, and integrates seamlessly with the web.
+          With an open-source, functional API, complex models can be created with just a few lines of code.
+        </p>
+        <p>
+          Create designs in the editor, or drag and drop local files.
+        </p>
+
+        <ul>
+          <li><a href="/docs/tutorial-01_gettingStarted.html" target="_blank">Getting Started</a></li>
+          <li><a href="/docs/" target="_blank">API Reference</a></li>
+          <li><a href="https://github.com/jscad/OpenJSCAD.org" target="_blank">GitHub</a></li>
+        </ul>
+      </div>
+
       <div class="layout" id="layout">
         <div id="root" solo style="overflow: hidden;">
           <div id="viewer"></div>
@@ -57,26 +77,6 @@
           <select id="export-format"></select>
           <button id="export-button">Export</button>
         </div>
-      </div>
-
-      <div id="welcome">
-        <h1>JSCAD</h1>
-        <p>
-          JSCAD is a tool for creating parametric 2D and 3D CAD designs using JavaScript code.
-        </p>
-        <p>
-          Code CAD offers more precise control over designs, enables parameterized customization of models, and integrates seamlessly with the web.
-          With an open-source, functional API, complex models can be created with just a few lines of code.
-        </p>
-        <p>
-          Create designs in the editor, or drag and drop local files.
-        </p>
-
-        <ul>
-          <li><a href="/docs/tutorial-01_gettingStarted.html" target="_blank">Getting Started</a></li>
-          <li><a href="/docs/" target="_blank">API Reference</a></li>
-          <li><a href="https://github.com/jscad/OpenJSCAD.org" target="_blank">GitHub</a></li>
-        </ul>
       </div>
 
       <div id="error-bar">

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -24,9 +24,10 @@ body.dark {
   color: #ccc;
 }
 
-.layout{
+.layout {
   flex: 1;
   display: flex;
+  min-width: 80px;
 }
 
 #root {

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -153,7 +153,6 @@ p {
 }
 
 #editor {
-  width: 400px;
   position: relative;
   transition: width 0.5s;
 }


### PR DESCRIPTION
Simple change, move code for the "resizeable drawer panel" out of `editor.js` and into its own `drawer.js` file.

Also includes minor changes:

 - set minimum width on the viewer so that you can't lose the resize toggle
 - code style of the hull example
 - remove unused `setCompileFun`
 - add GitHub link to welcome screen
 - add slicer example