### PR TITLE
format-jscad: support for V3 geometry data structures

### DIFF
--- a/apps/jscad-web/examples/slicer.example.js
+++ b/apps/jscad-web/examples/slicer.example.js
@@ -21,7 +21,7 @@ export const main = () => {
     // intersect with a cuboid
     const cutter = cuboid({
       size: [100, 100, thicness],
-      center: [0, 0, z]
+      center: [0, 0, z + thicness / 2]
     })
     const cut = intersect(obj, cutter)
 

--- a/apps/jscad-web/src/examples.js
+++ b/apps/jscad-web/src/examples.js
@@ -1,6 +1,6 @@
 export const examples = [
   { name: 'JSCAD Logo', source: './examples/jscad.example.js' },
-  { name: 'Primitives', source: './examples/primitives.example.js' },
+  { name: 'Primitive Shapes', source: './examples/primitives.example.js' },
   { name: 'Extrusions', source: './examples/extrusions.example.js' },
   { name: 'Hulls', source: './examples/hulls.example.js' },
   { name: 'Parametric Gear', source: './examples/gear.example.js' },

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -316,7 +316,7 @@ p {
 }
 .dark .cm-focused .cm-gutters,
 .dark .cm-focused .cm-activeLine {
-  background-color: #445;
+  background-color: #7777bb44;
 }
 .dark .cm-gutters,
 .dark .cm-activeLine {


### PR DESCRIPTION
This PR adds support for new JSCAD v3 geometry data structures being returned.

The changes in JSCAD v3 include:
 - `geom2` changed from using `sides` to `outlines`
 - `slice` is a first-class geometry now, and changed from `edges` to `contours`

Procedure for using JSCADUI with JSCAD v3 locally:

```bash
cd ~/jscad/packages/modeling
git checkout V3
npm link

cd ~/jscadui/apps/jscad-web
npm link @jscad/modeling
rm -rf build_dev
npm start
```

Very exciting!!