### PR TITLE
jscad-web: http server

### DIFF
--- a/apps/jscad-web/build.js
+++ b/apps/jscad-web/build.js
@@ -2,11 +2,12 @@ import { copyTask, parseArgs } from '@jsx6/build'
 import { execSync } from 'child_process'
 import { existsSync, mkdirSync } from 'fs'
 import liveServer from 'live-server'
+import {serve} from './serve.js'
 
 import { buildBundle, buildOne } from './src_build/esbuildUtil.js'
 
 // *************** read parameters **********************
-const { dev, port = 5120 } = parseArgs()
+const { dev, port = 5120, serve:serveBuild=false } = parseArgs()
 const watch = dev
 const outDir = dev ? 'build_dev' : 'build'
 const docsDir = 'jscad/docs'
@@ -56,6 +57,9 @@ await buildOne('.', outDir, 'main.js', watch, { format: 'esm', loader })
 
 /**************************** LIVE SERVER if in dev mode *************/
 // docs folder is too heavy for watch
-if (dev) liveServer.start({ root: outDir, port, open: false, ignore: outDir+'/docs' })
+if (dev) 
+  liveServer.start({ root: outDir, port, open: false, ignore: outDir+'/docs' })
+else 
+  if(serveBuild) serve(port)
 
 //*/

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -9,6 +9,7 @@ import * as editor from './src/editor.js'
 import * as engine from './src/engine.js'
 import * as exporter from './src/exporter.js'
 import * as menu from './src/menu.js'
+import * as remote from './src/remote.js'
 import { ViewState } from './src/viewState.js'
 import * as welcome from './src/welcome.js'
 
@@ -190,4 +191,9 @@ editor.init(defaultCode, async (script, path) => {
 })
 menu.init(loadExample)
 welcome.init()
+remote.init((script) => {
+  editor.setSource(script)
+  runScript({ script })
+  welcome.dismiss()
+})
 exporter.init(exportModel)

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -192,8 +192,13 @@ editor.init(defaultCode, async (script, path) => {
 menu.init(loadExample)
 welcome.init()
 remote.init((script) => {
+  // run remote script
   editor.setSource(script)
   runScript({ script })
+  welcome.dismiss()
+}, (err) => {
+  // show remote script error
+  setError(err)
   welcome.dismiss()
 })
 exporter.init(exportModel)

--- a/apps/jscad-web/package.json
+++ b/apps/jscad-web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node build.js --dev",
     "build": "node build.js",
-    "serve": "node build.js && node serve.js",
+    "serve": "node build.js --serve",
     "test": "ava"
   },
   "dependencies": {

--- a/apps/jscad-web/package.json
+++ b/apps/jscad-web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "node build.js --dev",
     "build": "node build.js",
+    "serve": "node build.js && node serve.js",
     "test": "ava"
   },
   "dependencies": {

--- a/apps/jscad-web/serve.js
+++ b/apps/jscad-web/serve.js
@@ -30,6 +30,9 @@ const handleRequest = (req) => {
   } else if (pathname.endsWith('/')) {
     // serve index.html
     return handleStatic(`${pathname}index.html`)
+  } else if (pathname === '/remote') {
+    // fetch remote script
+    return handleRemote(parsedUrl)
   } else {
     // serve static files
     return handleStatic(pathname)
@@ -57,6 +60,27 @@ const handleStatic = async (pathname) => {
 
   const content = await fs.readFile(filePath)
   return { status: 200, content, contentType }
+}
+
+/**
+ * Serve a remote script at a url
+ */
+const handleRemote = async (parsedUrl) => {
+  // parse url from query parameters
+  const scriptUrl = decodeURIComponent(parsedUrl.query.url)
+  if (scriptUrl) {
+    console.log('fetching remote url', scriptUrl)
+    const res = await fetch(scriptUrl)
+    if (res.ok) {
+      const content = await res.text()
+      return { status: 200, content, contentType: 'text/plain' }
+    } else {
+      console.warn(`failed to load remote url ${scriptUrl}`)
+      return { status: 404, content: 'not found' }
+    }
+  } else {
+    return { status: 400, content: 'missing url parameter' }
+  }
 }
 
 /* create http server */

--- a/apps/jscad-web/serve.js
+++ b/apps/jscad-web/serve.js
@@ -1,0 +1,97 @@
+import http from 'http'
+import fs from 'fs/promises'
+import path from 'path'
+import url from 'url'
+
+const port = 5120
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.map': 'application/json',
+  '.ico': 'image/x-icon',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.woff2': 'font/woff2',
+}
+
+/**
+ * Handles an http request
+ */
+const handleRequest = (req) => {
+  const parsedUrl = url.parse(req.url, true)
+  let pathname = parsedUrl.pathname
+
+  if (pathname === '/docs') {
+    // docs redirect
+    return { status: 301, content: '/docs/' }
+  } else if (pathname.endsWith('/')) {
+    // serve index.html
+    return handleStatic(`${pathname}index.html`)
+  } else {
+    // serve static files
+    return handleStatic(pathname)
+  }
+}
+
+/**
+ * Serve static files
+ */
+const handleStatic = async (pathname) => {
+  // serve static files from the build directory
+  let filePath = path.join(process.cwd(), 'build', pathname)
+
+  const stats = await fs.stat(filePath).catch(() => undefined)
+  if (!stats || !stats.isFile()) {
+    return { status: 404, content: 'not found' }
+  }
+
+  // detect content type
+  const extname = path.extname(filePath)
+  if (!mimeTypes[extname]) {
+    console.error(`serving unknown mimetype ${extname}`)
+  }
+  const contentType = mimeTypes[extname] || 'application/octet-stream'
+
+  const content = await fs.readFile(filePath)
+  return { status: 200, content, contentType }
+}
+
+/* create http server */
+const server = http.createServer(async (req, res) => {
+  const startTime = new Date()
+  let result = { status: 500, content: 'internal server error' }
+  try {
+    result = await handleRequest(req)
+  } catch (err) {
+    console.error('error handling request', err)
+  }
+
+  let { status, content, contentType } = result
+  // write http response
+  const headers = {}
+  if (contentType) headers['Content-Type'] = contentType
+  if (status === 301) {
+    // handle redirects
+    headers['Location'] = content
+    content = ''
+  }
+  res.writeHead(status, headers)
+  res.end(content)
+  // log request
+  const endTime = new Date()
+  const ms = endTime - startTime
+  const line = `${endTime.toISOString()} ${status} ${req.method} ${req.url} ${content.length} ${ms}ms`
+  if (status < 400) {
+    console.log(line)
+  } else {
+    // highlight errors
+    console.log(`\x1b[31m${line}\x1b[0m`)
+  }
+})
+
+server.listen(port, () => {
+  console.log(`JSCADUI running on http://localhost:${port}`)
+})

--- a/apps/jscad-web/serve.js
+++ b/apps/jscad-web/serve.js
@@ -3,8 +3,6 @@ import fs from 'fs/promises'
 import path from 'path'
 import url from 'url'
 
-const port = 5120
-
 const mimeTypes = {
   '.html': 'text/html',
   '.js': 'application/javascript',
@@ -115,6 +113,8 @@ const server = http.createServer(async (req, res) => {
   }
 })
 
-server.listen(port, () => {
-  console.log(`JSCADUI running on http://localhost:${port}`)
-})
+export function serve(port){
+  server.listen(port, () => {
+    console.log(`JSCADUI running on http://localhost:${port}`)
+  })
+}

--- a/apps/jscad-web/serve.js
+++ b/apps/jscad-web/serve.js
@@ -40,10 +40,9 @@ const handleRequest = (req) => {
 }
 
 /**
- * Serve static files
+ * Serve static files from the build directory
  */
 const handleStatic = async (pathname) => {
-  // serve static files from the build directory
   let filePath = path.join(process.cwd(), 'build', pathname)
 
   const stats = await fs.stat(filePath).catch(() => undefined)

--- a/apps/jscad-web/src/remote.js
+++ b/apps/jscad-web/src/remote.js
@@ -1,0 +1,23 @@
+
+export const init = (compileFn) => {
+  load(compileFn) // on load
+  window.addEventListener('hashchange', () => load(compileFn)) // on change
+}
+
+/**
+ * Handles a url passed in the anchor string
+ */
+export const load = async (compileFn) => {
+  const url = window.location.hash.substring(1)
+  if (url) {
+    console.log('fetching script', url)
+    // load from /remote
+    const res = await fetch(`/remote?url=${url}`)
+    if (res.ok) {
+      const script = await res.text()
+      compileFn(script, url)
+    } else {
+      throw new Error('failed to load remote')
+    }
+  }
+}

--- a/apps/jscad-web/src/remote.js
+++ b/apps/jscad-web/src/remote.js
@@ -1,23 +1,33 @@
 
-export const init = (compileFn) => {
-  load(compileFn) // on load
-  window.addEventListener('hashchange', () => load(compileFn)) // on change
+export const init = (compileFn, setError) => {
+  const load = loadFromUrl(compileFn, setError)
+  load() // on load
+  window.addEventListener('hashchange', load) // on change
 }
 
 /**
  * Handles a url passed in the anchor string
  */
-export const load = async (compileFn) => {
+export const loadFromUrl = (compileFn, setError) => async () => {
   const url = window.location.hash.substring(1)
   if (url) {
     console.log('fetching script', url)
     // load from /remote
-    const res = await fetch(`/remote?url=${url}`)
-    if (res.ok) {
-      const script = await res.text()
+    try {
+      const script = await fetchUrl(url)
       compileFn(script, url)
-    } else {
-      throw new Error('failed to load remote')
+    } catch (err) {
+      console.error('failed to load remote script', err)
+      setError(err)
     }
+  }
+}
+
+const fetchUrl = async (url) => {
+  const res = await fetch(`/remote?url=${url}`)
+  if (res.ok) {
+    return await res.text()
+  } else {
+    throw new Error(`failed to load script from url ${url}`)
   }
 }

--- a/apps/jscad-web/src/welcome.js
+++ b/apps/jscad-web/src/welcome.js
@@ -10,10 +10,10 @@ export const init = () => {
   window.addEventListener("dragover", () => dismiss())
 }
 
-const dismiss = (e) => {
+export const dismiss = (e) => {
   // dismiss if click on anything other than a link
   if (showing && (!e || !welcome.contains(e.target) || e.target.nodeName !== "A")) {
-    document.getElementById("welcome").style.display = "none"
+    welcome.style.display = "none"
     showing = false
   }
 }


### PR DESCRIPTION
This PR adds a minimal web server using the built in node `http` package (who needs dependencies anyway?)

It can be run with `npm run serve`

It also adds the neat feature from JSCAD v2 where you can load a script by url like:

https://jscad.app/#https://raw.githubusercontent.com/gilboonet/designs/master/2023/demo_creeMeuble2.js
(@gilboonet)

This required the following changes:
 - add `serve.js` which starts a minimal http server
 - handle serving static files from the `build` dir
 - handle `index.html` as default file
 - handle `/remote` endpoint which proxies fetch requests to cross domain urls
 - handle `/docs` redirect to `/docs/`
 - handle missing files, urls, etc
 - handle mimetype detection
 - server request logging
 - client side checking for `#url` in location

https://github.com/hrgdavor/jscadui/assets/1766297/c074534b-cb22-4490-bc77-dcdc6d434ee3
