### PR TITLE
fix: service worker init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ dist
 .turbo
 build/**
 dist/**
+**/.history

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -202,4 +202,17 @@ remote.init((script) => {
   welcome.dismiss()
 })
 exporter.init(exportModel)
-initFs()
+
+if ('serviceWorker' in navigator && !navigator.serviceWorker.controller) {
+  // service workers are disabled on hard-refresh, so need to reload.
+  // to prevent a reload loop, don't reload again within 3 seconds.
+  const lastReload = localStorage.getItem('lastReload')
+  if (!lastReload || Date.now() - lastReload > 3000) {
+    setError('cannot start service worker, reloading')
+    localStorage.setItem('lastReload', Date.now())
+    location.reload()
+  } else {
+    console.error('cannot start service worker, reload required')
+  }
+  setError('cannot start service worker, reload required')
+}

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -202,3 +202,4 @@ remote.init((script) => {
   welcome.dismiss()
 })
 exporter.init(exportModel)
+initFs()

--- a/packages/fs-provider/README.md
+++ b/packages/fs-provider/README.md
@@ -1,8 +1,32 @@
 # fs-provider
 
+
 Provider that fills cache for `fs-service-worker` that you need in your main script to fill files data.
 
 Use case is for creating a virtual folder that can be accessed by JavaScript during fetch or sync/async XMLHttpRequest. 
+
+## important known issue
+
+Service worker does not work after hard refresh: CTRL+F5 or CTR*+refresh. You can work around this by calling regular refresh.
+Service worker also does not work at all in incognito mode, and there maybe other reasons it does not work. It is important
+to check if reload was already called to avoid infinite reloading of the page. Here is a sample snippet that does that tht you can customize.
+
+```js
+if ('serviceWorker' in navigator && !navigator.serviceWorker.controller) {
+  // service workers are disabled on hard-refresh, so need to reload.
+  // to prevent a reload loop, don't reload again within 3 seconds.
+  const lastReload = localStorage.getItem('lastReload')
+  if (!lastReload || Date.now() - lastReload > 3000) {
+    console.error('cannot start service worker, reloading')
+    localStorage.setItem('lastReload', Date.now())
+    location.reload()
+  } else {
+    console.error('cannot start service worker, reload required')
+  }
+}
+
+```
+
 
 ## utilities for `FileReader`
 

--- a/packages/fs-provider/fs-provider.js
+++ b/packages/fs-provider/fs-provider.js
@@ -70,6 +70,18 @@ export const addPreLoad = async (sw, path, ignoreMissing) => {
  */
 export const registerServiceWorker = async (workerScript, _getFile = getFile, { prefix = '/swfs/' } = {}) => {
   if ('serviceWorker' in navigator) {
+    try {
+      let registration = await navigator.serviceWorker.register(workerScript, {
+        scope: '/',
+      })
+      for (let i = 1; i <= 10; i++) {
+        if (registration.active) break
+        registration = await navigator.serviceWorker.getRegistration()
+      }
+    } catch (error) {
+      console.error(`service worker registration failed with ${error}`)
+    }
+
     if (!navigator.serviceWorker.controller) {
       // service workers are disabled on hard-refresh, so need to reload.
       // to prevent a reload loop, don't reload again within 3 seconds.
@@ -82,18 +94,6 @@ export const registerServiceWorker = async (workerScript, _getFile = getFile, { 
         console.error('cannot start service worker, reload required')
       }
       throw new Error('cannot start service worker, reload required')
-    }
-
-    try {
-      let registration = await navigator.serviceWorker.register(workerScript, {
-        scope: '/',
-      })
-      for (let i = 1; i <= 10; i++) {
-        if (registration.active) break
-        registration = await navigator.serviceWorker.getRegistration()
-      }
-    } catch (error) {
-      console.error(`Registration failed with ${error}`)
     }
 
     /** @type {SwHandler} */
@@ -131,6 +131,8 @@ export const registerServiceWorker = async (workerScript, _getFile = getFile, { 
     checkFiles(sw)
   
     return sw
+  } else {
+    throw new Error('service worker unavailable')
   }
 }
 

--- a/packages/fs-provider/fs-provider.js
+++ b/packages/fs-provider/fs-provider.js
@@ -82,20 +82,6 @@ export const registerServiceWorker = async (workerScript, _getFile = getFile, { 
       console.error(`service worker registration failed with ${error}`)
     }
 
-    if (!navigator.serviceWorker.controller) {
-      // service workers are disabled on hard-refresh, so need to reload.
-      // to prevent a reload loop, don't reload again within 3 seconds.
-      const lastReload = localStorage.getItem('lastReload')
-      if (!lastReload || Date.now() - lastReload > 3000) {
-        console.log('cannot start service worker, reloading')
-        localStorage.setItem('lastReload', Date.now())
-        location.reload()
-      } else {
-        console.error('cannot start service worker, reload required')
-      }
-      throw new Error('cannot start service worker, reload required')
-    }
-
     /** @type {SwHandler} */
     const sw = initMessaging(navigator.serviceWorker, {
       getFile: async ({ path }) => {


### PR DESCRIPTION
Was having issue with service worker on jscad.app, so I did some debugging. I think this should now properly handle all the cases:

 - normal browser (with and without sw loaded already)
 - private browser
 - hard refresh ctrl-shift-r (service worker initially disabled by browser, so reload)
 
Note: I now call `initFs` at startup. Previously this would only happen on file drop, but that led to bad user experience where: after a hard refresh, user drops file, page reloads but user has no indication of why dropping their file didn't work, and that they need to drop it again. By moving `initFs` to page load, it will refresh if needed BEFORE the user drops anything.
