### PR TITLE
jscad-web: fix default model

### DIFF
--- a/apps/jscad-web/examples/hulls.example.js
+++ b/apps/jscad-web/examples/hulls.example.js
@@ -1,5 +1,5 @@
 /**
- * Demonstrates Hull and Hull Chain operations in two and three dimensions
+ * Demonstrates Hull and Hull Chain operations in 2D and 3D
  */
 
 import * as jscad from '@jscad/modeling'
@@ -18,10 +18,10 @@ export const main = (params) => {
     circle({ center: [5, 8], radius })
   ]
   const shapes3d = [
-    sphere({ center: [-5, 30, 0], radius, segments }),
     sphere({ center: [-5, 18, 0], radius, segments }),
-    sphere({ center: [5, 18, 0], radius, segments }),
-    sphere({ center: [5, 30, 0], radius, segments })
+    sphere({ center: [-3, 30, 0], radius, segments }),
+    sphere({ center: [3, 30, 0], radius, segments }),
+    sphere({ center: [5, 18, 0], radius, segments })
   ]
   return [
     colorize([1.0, 0.0, 0.0], translate([-20, 0, 0], [shapes2d, shapes3d])),

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -25,6 +25,9 @@ byId('overlay').appendChild(gizmo)
 
 let model = []
 
+// load default model unless another model was already loaded
+let loadDefault = true
+
 const ctrl = (window.ctrl = new OrbitControl([byId('viewer')], { ...viewState.camera, alwaysRotate: false }))
 
 const updateFromCtrl = change => {
@@ -151,7 +154,9 @@ sendCmdAndSpin('init', {
     '@jscad/modeling': toUrl('./build/bundle.jscad_modeling.js'),
   },
 }).then(() => {
-  runScript({ script: defaultCode })
+  if (loadDefault) {
+    runScript({ script: defaultCode })
+  }
 })
 
 const paramChangeCallback = params => {
@@ -160,6 +165,7 @@ const paramChangeCallback = params => {
 }
 
 const runScript = async ({ script, url = './index.js', base, root }) => {
+  loadDefault = false // don't load default model if something else was loaded
   const result = await sendCmdAndSpin('runScript', { script, url, base, root })
   genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
 }

--- a/apps/jscad-web/src/welcome.js
+++ b/apps/jscad-web/src/welcome.js
@@ -1,13 +1,15 @@
 const welcome = document.getElementById("welcome")
 let showing = true
 
-// Hide the welcome menu when anything is clicked
 export const init = () => {
+  // hide the welcome menu when anything is clicked
   window.addEventListener("mousedown", (e) => dismiss(e))
   window.addEventListener("click", (e) => dismiss(e))
   window.addEventListener("drop", () => dismiss())
   window.addEventListener("dragstart", () => dismiss())
   window.addEventListener("dragover", () => dismiss())
+  // hello devs
+  console.log('Welcome to JSCAD! Like JavaScript and want to help? Join us at https://github.com/jscad/OpenJSCAD.org')
 }
 
 export const dismiss = (e) => {

--- a/apps/jscad-web/static/robots.txt
+++ b/apps/jscad-web/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
1. there was an issue where if you either load a model via remote url, or if you're quick about drag-and-dropping a file, the default model will load AFTER it, and replace the content. This PR fixes that by disabling default model loading once any other model has been loaded
2. add `robots.txt` file (allow all)
3. cleanup the `serve.js` code style
4. tweak hull example to show how it can be used to make a shape that **isn't** just a rounded rectangle
5. easter egg: add a greeting message to any users who open the dev console. `Welcome to JSCAD! Like JavaScript and want to help? Join us at https://github.com/jscad/OpenJSCAD.org`
