### PR TITLE
Extract stacktrace from eval

### DIFF
--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -10,6 +10,7 @@ import * as engine from './src/engine.js'
 import * as exporter from './src/exporter.js'
 import * as menu from './src/menu.js'
 import * as remote from './src/remote.js'
+import { formatStacktrace } from './src/stacktrace.js'
 import { ViewState } from './src/viewState.js'
 import * as welcome from './src/welcome.js'
 
@@ -99,7 +100,7 @@ document.body.ondragleave = document.body.ondragend = ev => {
 const setError = error => {
   const errorBar = byId('error-bar')
   if (error) {
-    const message = error.toString().replace(/^Error: /, '')
+    const message = formatStacktrace(error).replace(/^Error: /, '')
     const errorMessage = byId('error-message')
     errorMessage.innerText = message
     errorBar.classList.add('visible')

--- a/apps/jscad-web/src/stacktrace.js
+++ b/apps/jscad-web/src/stacktrace.js
@@ -1,0 +1,26 @@
+/**
+ * Extracts the stacktrace for an error thrown from inside an eval function.
+ * Returns the stacktrace as a string for just the code running inside eval.
+ *
+ * @param {Error} error
+ * @returns {string} - stacktrace for code inside eval
+ */
+export const formatStacktrace = (error) => {
+  // error.stack is not standard but works on chrome and firefox
+  if (!error.stack) return error.toString()
+
+  // chrome stacktrace (script error, syntax error):
+  // at main (eval at <anonymous> (eval at <anonymous> (require.js:24:69)), <anonymous>:13:3)
+  // at eval (eval at <anonymous> (require.js:24:69), <anonymous>:3:12)
+  // firefox stacktrace:
+  // main@http://localhost:5120/build/bundle.worker.js line 14 > eval line 1 > eval:13:3
+  // @http://localhost:5120/build/bundle.worker.js line 14 > eval:1:37
+  const cleaned = error.stack.split('\n')
+    .filter((line) => line.includes('eval'))
+    .map((line) => line.replace(/eval at <anonymous> \(.*?\), /, '')) // chrome
+    .map((line) => line.replace(/^@/, '<anonymous>@')) // firefox
+    .map((line) => line.replace(/@http.*?bundle.worker.js.* > eval:/, ' ')) // firefox
+    .map((line) => line.replace(/^\s*(at )?/, '  at ')) // indent
+
+  return [error.toString(), ...cleaned].join('\n')
+}

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -63,11 +63,14 @@ body.dark {
 #dropModal {
   display: none;
   position: fixed;
+  padding: 5px;
+  text-align: center;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   background-color: rgba(0,0,0,0.5);
+  z-index: 5000;
 }
 
 jscadui-gizmo {
@@ -590,6 +593,7 @@ p {
   font-family: monospace;
   overflow-y: auto;
   transition: max-height 0.4s;
+  pointer-events: all;
 }
 #error-bar.visible {
   max-height: 40%;


### PR DESCRIPTION
This PR adds stacktrace support to jscad.app

![stacktrace](https://github.com/hrgdavor/jscadui/assets/1766297/f001d1cf-b5d8-4941-bc64-d43c8e04906e)

Previously this would have just given `error.toString()` but now it gives a full stacktrace.

Changes:
 - Add `formatStacktrace` function which parses a stacktrace and extracts the lines which were inside the `eval` function.
 - Remove noise from stacktrace introduced by `eval`
 - Serialize `stack` specifically in `postmessage` because otherwise it gets lost in transit (necessary for firefox)
