### PR TITLE
Fix require edge cases

### DIFF
--- a/apps/engine-test/main.js
+++ b/apps/engine-test/main.js
@@ -126,7 +126,7 @@ document.body.ondrop = async ev => {
     sendCmd('clearTempCache', {})
     const { alias, script } = await fileDropped(sw, files)
     projectName = sw.projectName
-    if (alias?.length) {
+    if (alias.length) {
       sendNotify('init', { alias })
     }
     runScript({ url: sw.fileToRun, base: sw.base })

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -151,7 +151,7 @@ async function sendCmdAndSpin(method, params) {
 }
 
 sendCmdAndSpin('init', {
-  bundles: {
+  bundles: {// local bundled alias for common libs.
     '@jscad/modeling': toUrl('./build/bundle.jscad_modeling.js'),
     '@jscad/io': toUrl('./build/bundle.jscad_io.js'),
   },

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -74,7 +74,7 @@ document.body.ondrop = async ev => {
     sendCmd('clearTempCache', {})
     const { alias, script } = await fileDropped(sw, files)
     projectName = sw.projectName
-    if (alias?.length) {
+    if (alias.length) {
       sendNotify('init', { alias })
     }
     runScript({ url: sw.fileToRun, base: sw.base })

--- a/packages/fs-provider/fs-provider.js
+++ b/packages/fs-provider/fs-provider.js
@@ -129,7 +129,7 @@ export const clearFs = async sw => {
 }
 
 export const clearCache = async cache => {
-  await cache.keys(key => cache.delete(key))
+  (await cache.keys()).forEach(key => cache.delete(key))
 }
 
 export const extractEntries = dt => {

--- a/packages/fs-provider/fs-provider.js
+++ b/packages/fs-provider/fs-provider.js
@@ -228,26 +228,7 @@ export async function fileDropped(sw, files) {
   rootFiles = rootFiles.map(e => fileToFsEntry(e, '/'))
   sw.roots.push(rootFiles)
 
-  const alias = []
-  let pkgFile = await findFileInRoots(sw.roots, 'package.json')
-  if (pkgFile) {
-    try {
-      const pack = JSON.parse(await readAsText(pkgFile))
-      if (pack.main) sw.fileToRun = pack.main
-      if (pack.workspaces)
-        for (let i = 0; i < pack.workspaces.length; i++) {
-          const w = pack.workspaces[i]
-          // debugger
-          let pack2 = await findFileInRoots(sw.roots, `/${w}/package.json`)
-          if (pack2) pack2 = JSON.parse(await readAsText(pack2))
-          let name = pack2?.name || w
-          let main = pack2?.main || 'index.js'
-          alias.push([`/${w}/${main}`, name])
-        }
-    } catch (error) {
-      console.error('error parsing package.json', error)
-    }
-  }
+  const alias = await getWorkspaceAliases(sw)
 
   let time = Date.now()
   const preLoad = ['/' + sw.fileToRun, '/package.json']
@@ -270,6 +251,37 @@ export async function fileDropped(sw, files) {
     }
   }
   return {alias, script}
+}
+
+/**
+ * Parse package.json, and return a list of workspace aliases.
+ * Also parses the main file to run, if any.
+ *
+ * @param {SwHandler} sw
+ * @returns {Array}
+ */
+const getWorkspaceAliases = async (sw) => {
+  const alias = []
+  let pkgFile = await findFileInRoots(sw.roots, 'package.json')
+  if (pkgFile) {
+    try {
+      const pack = JSON.parse(await readAsText(pkgFile))
+      if (pack.main) sw.fileToRun = pack.main
+      if (pack.workspaces)
+        for (let i = 0; i < pack.workspaces.length; i++) {
+          const w = pack.workspaces[i]
+          // debugger
+          let pack2 = await findFileInRoots(sw.roots, `/${w}/package.json`)
+          if (pack2) pack2 = JSON.parse(await readAsText(pack2))
+          let name = pack2?.name || w
+          let main = pack2?.main || 'index.js'
+          alias.push({ name, path: `/${w}/${main}` })
+        }
+    } catch (error) {
+      throw new Error(`failed to parse package.json\n  ${error}`)
+    }
+  }
+  return alias
 }
 
 export const findByFsPath = (arr, file) => {

--- a/packages/postmessage/index.js
+++ b/packages/postmessage/index.js
@@ -74,10 +74,27 @@ const messageSender = _self => {
       throw error
     }
   }
+
+  /**
+   * Send a message with no response
+   *
+   * @param {string} method
+   * @param {object} params
+   * @param {Array} trans
+   */
   const sendNotify = (method, params = {}, trans = []) => {
     _self.postMessage({ method, params }, fixTransfer(trans))
   }
 
+  /**
+   * Send a message with response expected
+   *
+   * @param {string} method
+   * @param {object} params
+   * @param {Array} trans
+   * @param {number?} timeout
+   * @returns {Promise} resolves when response is received
+   */
   const sendCmd = (method, params = {}, trans = [], timeout) => {
     const id = seq++
     _self.postMessage({ method, params, id }, fixTransfer(trans))
@@ -98,7 +115,7 @@ const messageSender = _self => {
 
 /**
  *
- * @param {*} _self reference to self of the main widnow (self) or reference to a worker
+ * @param {*} _self reference to self of the main window (self) or reference to a worker
  * @param {*} handlers - object where key if method name, and value ih handler
  * @returns
  */

--- a/packages/require/src/readFileWeb.js
+++ b/packages/require/src/readFileWeb.js
@@ -1,7 +1,7 @@
 // it is possible to read binary data
 // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data
 
-export const readFileWeb = (path, {base = '', output='text'})=>{
+export const readFileWeb = (path, {base = '', output='text'}={}) => {
   const req = new XMLHttpRequest()
   req.open('GET', base ? new URL(path, base) : path, 0) // sync
   req.send()

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -120,16 +120,19 @@ export function require(urlOrSource, transform, _readFile=readFileWeb, _base, ro
 export function requireModule(url, source, _require) {
   try {
     const exports = {}
-    const module = { id: url, uri: url, exports: exports, source } // according to node.js modules
+    const module = { id: url, uri: url, exports, source } // according to node.js modules
     //module.require = _require
     runModule(_require, exports, module, source)
     return module
   } catch (err) {
-    console.error('error loading module ' + url, err)
-    throw err
+    console.error('failed loading module', url, err)
+    throw new Error(`failed loading module ${url}\n  ${err}`)
   }
 }
 
+/**
+ * Clear file cache for specific files. Used when a file has changed.
+ */
 export const clearFileCache = async ({files}) => {
   const cache = requireCache.local
   files.forEach(f=>{
@@ -137,7 +140,10 @@ export const clearFileCache = async ({files}) => {
   })
 }
 
-export const clearTempCache = async ({}) => {
+/**
+ * Clear project-specific cache
+ */
+export const clearTempCache = () => {
   requireCache.local = {}
   requireCache.alias = {}
 }

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -59,8 +59,8 @@ export function require(urlOrSource, transform, _readFile=readFileWeb, _base, ro
 
     if (isModule) {
       readFile = readModule
-      base = root = url + '/'
     }
+    base = url
 
     cache = requireCache[isRelativeFile ? 'local':'module']
     exports = cache[cacheUrl] // get from cache

--- a/packages/require/src/resolveUrl.js
+++ b/packages/require/src/resolveUrl.js
@@ -32,7 +32,6 @@ const splitModuleName = (module) => {
 export const resolveUrl = (url, base, root, moduleBase=MODULE_BASE) => {
   let isRelativeFile = false
   let isModule = false
-  let cacheUrl = url
   
   if (!/^(http:|https:|fs:|file:)/.test(url)) {
     // npm modules cannot start with . or /
@@ -67,10 +66,9 @@ export const resolveUrl = (url, base, root, moduleBase=MODULE_BASE) => {
         url = url.substring(1)
       }
       if (!getExtension(url)) url += '.js'
-      cacheUrl = `/${url}`
       // now create the full url to load the file
       url = new URL(url, root).toString()
     }
   }
-  return { url, isRelativeFile, isModule, cacheUrl }
+  return { url, isRelativeFile, isModule }
 }

--- a/packages/require/test/resolveUrl.test.js
+++ b/packages/require/test/resolveUrl.test.js
@@ -5,11 +5,13 @@ import { resolveUrl } from '../src/resolveUrl.js'
 const localBase = 'http://localhost:5120/swfs/5810d898-ed92-4d48-b22f-1b7d6353117a/'
 const remoteBase = 'https://cdn.jsdelivr.net/npm/@jscad/io-utils/'
 const root = 'http://localhost:5120/swfs/5810d898-ed92-4d48-b22f-1b7d6353117a/'
+const fsRoot = 'fs:/'
 
 it('local file', () => {
   const expected = 'http://localhost:5120/swfs/5810d898-ed92-4d48-b22f-1b7d6353117a/imported.js'
   expect(resolveUrl('./imported.js', '/index.js', root).url).toEqual(expected)
   expect(resolveUrl('./imported.js', localBase, root).url).toEqual(expected)
+  expect(resolveUrl('./src/util.js', '/util/index.js', fsRoot).url).toEqual('fs:/util/src/util.js')
 })
 
 it('npm package', () => {
@@ -18,10 +20,16 @@ it('npm package', () => {
 })
 
 it('npm package internal file', () => {
-  expect(resolveUrl('@jscad/io-utils/convertToBlob', localBase, root).url).toEqual('https://cdn.jsdelivr.net/npm/@jscad/io-utils/convertToBlob.js')
+  expect(resolveUrl('@jscad/io-utils/convertToBlob', localBase, root).url)
+    .toEqual('https://cdn.jsdelivr.net/npm/@jscad/io-utils/convertToBlob.js')
 })
 
 it('npm package relative', () => {
   expect(resolveUrl('./convertToBlob.js', remoteBase, root).url)
     .toEqual('https://cdn.jsdelivr.net/npm/@jscad/io-utils/convertToBlob.js')
+})
+
+it('http url', () => {
+  expect(resolveUrl('http://localhost:5120/build/bundle.jscad_modeling.js', localBase, root).url)
+    .toEqual('http://localhost:5120/build/bundle.jscad_modeling.js')
 })

--- a/packages/require/test/workspace.import.test.js
+++ b/packages/require/test/workspace.import.test.js
@@ -1,7 +1,7 @@
 import { transformcjs } from '@jscadui/transform-babel'
 import { expect, it } from 'vitest'
 
-import { makeReadFileNode, readFileNode } from '../src/readFileNode.js'
+import { makeReadFileNode } from '../src/readFileNode.js'
 import { require, requireCache } from '../src/require.js'
 
 const root = 'test/workspace/import/'
@@ -10,13 +10,11 @@ const base = 'fs:/'
 it('no_transform', () => {
   const readFileNode = makeReadFileNode(root)
   let pack = JSON.parse(readFileNode('/package.json'))
-  // console.log('pack', pack)
   pack.workspaces?.forEach(w => {
     // todo move to utility
     let pack = JSON.parse(readFileNode(`/${w}/package.json`))
     let name = pack?.name || w
     let main = pack?.main || 'index.js'
-    console.log('pack', pack)
     requireCache.alias[name] = new URL(`./${w}/${main}`, base).toString()
   })
   let script = require('/index.js', transformcjs, readFileNode, base)

--- a/packages/require/test/workspace.import2level.test.js
+++ b/packages/require/test/workspace.import2level.test.js
@@ -1,7 +1,7 @@
 import { transformcjs } from '@jscadui/transform-babel'
 import { expect, it } from 'vitest'
 
-import { makeReadFileNode, readFileNode } from '../src/readFileNode.js'
+import { makeReadFileNode } from '../src/readFileNode.js'
 import { require, requireCache } from '../src/require.js'
 
 const root = 'test/workspace/import2level/'
@@ -10,15 +10,13 @@ const base = 'fs:/'
 it('no_transform', () => {
   const readFileNode = makeReadFileNode(root)
   let pack = JSON.parse(readFileNode('/package.json'))
-  // console.log('pack', pack)
   pack.workspaces?.forEach(w => {
     // todo move to utility
     let pack = JSON.parse(readFileNode(`/${w}/package.json`))
     let name = pack?.name || w
     let main = pack?.main || 'index.js'
-    console.log('pack', pack)
     requireCache.alias[name] = new URL(`./${w}/${main}`, base).toString()
   })
-  let script = require('/index.js', transformcjs, readFileNode, base)
+  let script = require('/index.js', transformcjs, readFileNode, base, base)
   expect(script.main({ size: 33 })).toEqual('cube33')
 })

--- a/packages/worker/worker.js
+++ b/packages/worker/worker.js
@@ -32,14 +32,8 @@ export const init = params => {
 
   if (bundles) Object.assign(requireCache.bundleAlias, bundles)
   // workspace aliases
-  alias?.forEach(arr => {
-    const [orig, ...aliases] = arr
-    aliases.forEach(a => {
-      requireCache.alias[a] = orig
-      if (a.toLowerCase().substr(-3) !== '.js') {
-        requireCache.alias[a + '.js'] = orig
-      }
-    })
+  alias.forEach(({ name, path }) => {
+    requireCache.alias[name] = path
   })
   console.log('init alias', alias, 'bundles',bundles)
   userInstances = params.userInstances

--- a/packages/worker/worker.js
+++ b/packages/worker/worker.js
@@ -1,6 +1,6 @@
 import { JscadToCommon } from '@jscadui/format-jscad'
 import { initMessaging, withTransferable } from '@jscadui/postmessage'
-import { clearFileCache, clearTempCache, readFileWeb, require, requireCache, requireModule, resolveUrl } from '@jscadui/require'
+import { clearFileCache, clearTempCache, readFileWeb, require, requireCache, resolveUrl } from '@jscadui/require'
 
 import { exportStlText } from './exportStlText.js'
 import { combineParameterDefinitions, getParameterDefinitionsFromSource } from './getParameterDefinitionsFromSource.js'
@@ -68,13 +68,13 @@ const importReg = /import(?:(?:(?:[ \n\t]+([^ *\n\t\{\},]+)[ \n\t]*(?:,|[ \n\t]+
 const exportReg = /export.*from/
 
 const runScript = async ({ script, url, base=globalBase, root=base }) => {
-  if(!script) script = readFileWeb(resolveUrl(url, base, root).url,{base})
+  if(!script) script = readFileWeb(resolveUrl(url, base, root).url)
 
   console.log('{ script, url, base, root }', { script, url, base, root })
   const shouldTransform = url.endsWith('.ts') || script.includes('import') && (importReg.test(script) || exportReg.test(script))
   let def = []
 
-  const scriptModule = require({url,script}, shouldTransform ? transformFunc : undefined, readFileWeb, base, root, readFileWeb)
+  const scriptModule = require({url,script}, shouldTransform ? transformFunc : undefined, readFileWeb, base, root)
   const fromSource = getParameterDefinitionsFromSource(script)
   def = combineParameterDefinitions(fromSource, await scriptModule.getParameterDefinitions?.())
   main = scriptModule.main

--- a/packages/worker/worker.js
+++ b/packages/worker/worker.js
@@ -31,6 +31,7 @@ export const init = params => {
   if (baseURI) globalBase = baseURI
 
   if (bundles) Object.assign(requireCache.bundleAlias, bundles)
+  // workspace aliases
   alias?.forEach(arr => {
     const [orig, ...aliases] = arr
     aliases.forEach(a => {


### PR DESCRIPTION
Very small PR that fixes two issues:

1. Fix `clearCache` function which was doing nothing, due to misuse of `Cache.keys()` function.

2. Fix regression on relative imports.  For example, import `./brother.js` from `src/sister.js` was missing `src` from base path, and so it would look in the top level directory instead of the `src` folder. This worked previously but was regressed by #51.

`index.js`:
```js
const bro = require('./src/brother.js')
```

`src/brother.js`:
```js
const sis = require('./sister.js')
```

`src/sister.js`:
```js
module.exports = { main: () => [] }
```