### PR TITLE
fix other apps

### DIFF
--- a/apps/cardboard-cutter/README.md
+++ b/apps/cardboard-cutter/README.md
@@ -3,14 +3,14 @@
 This is a project that aims to build a simple set of scripts that can be included in a HTML page to show JSCAD models. It is work in progress, but will likely improve based on user feedback.
 
 # bundle your scripts
-To bundle your scripts you can use this `esbuild ` command:
+
+To bundle your scripts you can use this `esbuild` command:
 
 ```sh
-esbuild .\script.js --bundle --external:@jscad/modeling --outdir=build  
+esbuild .\script.js --bundle --external:@jscad/modeling --outdir=build
 --sourcemap=inline --format=cjs --watch
 ```
 
-This way `@jscad/modeling` will not be included in the bundle, and that is ok because worker has it available unlike other dependencies that you might have. You can drag and drop the generated script on http://openjscad.xyz and develop it even further before including with your HTML page.
+This way `@jscad/modeling` will not be included in the bundle, and that is ok because worker has it available unlike other dependencies that you might have. You can drag and drop the generated script on https://jscad.app and develop it even further before including with your HTML page.
 
 `--sourcemap=inline` option is gives line numbers when errors occur, it is nice while developing, but can be omitted for production build.
-

--- a/apps/cardboard-cutter/index.html
+++ b/apps/cardboard-cutter/index.html
@@ -16,7 +16,7 @@
       <div id="root" style="overflow: hidden"></div>
     </div>
     <script type="module">
-      import { initEngine, runFile } from './build/main.js'
+      import { initEngine, runScript } from './build/main.js'
       // you can define bundles that are loaded by the worker and not bundled width a script
       // not bundling @jscad/modeling makes sense as soon as you have more than one script you want to show
       // esbuild howto: to bundle all imports except @jscad/modeling use: --external:@jscad/modeling
@@ -27,8 +27,9 @@
           '@jscad/io': document.baseURI+'build/bundle.jscad_io.js',
         },
       }
-      await initEngine(THREE, 'root', workerOptions)
-      runFile('./jscad/sqed/index.js')
+      initEngine(THREE, 'root', workerOptions).then(() => {
+        runScript('./jscad/sqed/index.js')
+      })
     </script>
   </body>
 </html>

--- a/apps/cardboard-cutter/main.js
+++ b/apps/cardboard-cutter/main.js
@@ -127,9 +127,9 @@ const paramChangeCallback = params => {
   sendCmd('runMain', { params })
 }
 
-export const runFile = file => {
-  console.warn('runFile', file)
-  sendCmd('runScript', { url:file }).then(result => {
+export const runScript = file => {
+  fileToRun = file.replace(/.*\//, '').replace(/\..*/, '')
+  sendCmd('runScript', { url: file }).then(result => {
     console.log('result', result)
     genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
   })

--- a/apps/jscad-examples/README.md
+++ b/apps/jscad-examples/README.md
@@ -5,23 +5,23 @@ This is a project that aims to build a simple set of scripts that can be include
 To run the demo first go to root folder of this repository and run `npm i`
 
 then come back to this project and start it
+
 ```
-cd apps/model-page
+cd apps/jscad-examples
 npm start
 ```
 
-you must run `npm i` only when you fresly checkout the project or deps change
-
+you must run `npm i` only when you freshly checkout the project or deps change
 
 # if you need bundle your JSCAD scripts
-To bundle your scripts you can use this `esbuild ` command:
+
+To bundle your scripts you can use this `esbuild` command:
 
 ```sh
-esbuild .\script.js --bundle --external:@jscad/modeling --outdir=build  
+esbuild .\script.js --bundle --external:@jscad/modeling --outdir=build
 --sourcemap=inline --format=cjs --watch
 ```
 
-This way `@jscad/modeling` will not be included in the bundle, and that is ok because worker has it available unlike other dependencies that you might have. You can drag and drop the generated script on http://openjscad.xyz and develop it even further before including with your HTML page.
+This way `@jscad/modeling` will not be included in the bundle, and that is ok because worker has it available unlike other dependencies that you might have. You can drag and drop the generated script on https://jscad.app and develop it even further before including with your HTML page.
 
 `--sourcemap=inline` option is gives line numbers when errors occur, it is nice while developing, but can be omitted for production build.
-

--- a/apps/jscad-examples/examples/core/extrusions/nutsAndBolts.js
+++ b/apps/jscad-examples/examples/core/extrusions/nutsAndBolts.js
@@ -18,12 +18,12 @@ const { translate } = jscad.transforms
 const options = {
   hexWidth: 10,
   hexHeight: 8,
-  threadLength: 32,
+  threadLength: 24,
   threadSize: 4,
   innerRadius: 4,
   outerRadius: 5.6,
   slicesPerRevolution: 12,
-  segments: 32
+  segments: 20
 }
 
 const main = () => {

--- a/apps/jscad-examples/examples/index.js
+++ b/apps/jscad-examples/examples/index.js
@@ -1,0 +1,32 @@
+/**
+ * Parametric design that lets you select an example to run
+ */
+
+const primitives3d = require('./core/primitives/primitives3D.js')
+const basicColors = require('./core/colors/basicColors.js')
+const basicBooleans = require('./core/booleans/basicBooleans.js')
+const nutsAndBolts = require('./core/extrusions/nutsAndBolts.js')
+
+const examples = {
+  primitives3d: { main: primitives3d.main, caption: 'Primitives 3D' },
+  basicColors: { main: basicColors.main, caption: 'Basic Colors' },
+  basicBooleans: { main: basicBooleans.main, caption: 'Basic Booleans' },
+  nutsAndBolts: { main: nutsAndBolts.main, caption: 'Nuts and Bolts' },
+}
+
+const getParameterDefinitions = () => [
+  {
+    name: 'example',
+    type: 'choice',
+    caption: 'Examples:',
+    values: Object.entries(examples).map(([k, v]) => k),
+    captions: Object.entries(examples).map(([k, v]) => v.caption),
+    initial: 'basicColors',
+  },
+]
+
+const main = (params) => {
+  return examples[params.example].main()
+}
+
+module.exports = { main, getParameterDefinitions }

--- a/apps/jscad-examples/index.html
+++ b/apps/jscad-examples/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="main.css" />
     <script src="build/bundle.threejs.js"></script>
-    <title>jscad model demo page</title>
+    <title>jscad examples</title>
   </head>
   <body>
     <div class="layout" id="layout">
@@ -16,7 +16,7 @@
       <div id="root" style="overflow: hidden"></div>
     </div>
     <script type="module">
-      import { initEngine, runFile } from './build/main.js'
+      import { initEngine, runScript } from './build/main.js'
       // you can define bundles that are loaded by the worker and not bundled width a script
       // not bundling @jscad/modeling makes sense as soon as you have more than one script you want to show
       // esbuild howto: to bundle all imports except @jscad/modeling use: --external:@jscad/modeling
@@ -26,8 +26,9 @@
           '@jscad/modeling': document.baseURI+'build/bundle.jscad_modeling.js',
         },
       }
-      await initEngine(THREE, 'root', workerOptions)
-      runFile('jscad/planter.mesh.js')
+      initEngine(THREE, 'root', workerOptions).then(() => {
+        runScript('./examples/index.js')
+      })
     </script>
   </body>
 </html>

--- a/apps/jscad-examples/main.js
+++ b/apps/jscad-examples/main.js
@@ -127,8 +127,9 @@ const paramChangeCallback = params => {
   sendCmd('runMain', { params })
 }
 
-export const runFile = file => {
-  sendCmd('runFile', { file }).then(result => {
+export const runScript = file => {
+  fileToRun = file.replace(/.*\//, '').replace(/\..*/, '')
+  sendCmd('runScript', { url: file }).then(result => {
     console.log('result', result)
     genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
   })

--- a/apps/jscad-web/README.md
+++ b/apps/jscad-web/README.md
@@ -1,26 +1,29 @@
-# JSCAD UI test app
+# JSCAD web app
 
-If you want to discuss jscad or jscadui you can also join us on discord: https://discord.gg/AaqGskur93
+This is the JSCAD web application hosted at https://jscad.app
 
-you must install modules from root of the project because it uses workspaces
+If you want to discuss jscad or jscadui, please join us on discord: https://discord.gg/AaqGskur93
 
-go to root fodler of the project
+## Running Locally
+
+You must install modules from root of the project because it uses npm workspaces.
+
+After cloning the project, go to the root folder of the checked out jscadui repo. Then install npm dependencies by running:
 
 ```
 npm i
 ```
 
-go back to apps/engine-test and run
+To start the local development server, go to the `apps/jscad-web` directory and run:
 
 ```
 npm start
 ```
 
+## Deployment
 
-This is a test app for different aspects of JSCAD UI.
+To start the production server run:
 
-It can run multiple engines in parallel or single engine on/off to be 
-able to sometimes test faster (running only one engine) or to test multiple engines to compare performance or compare any display differences between them.
-
-
-
+```
+npm run serve
+```

--- a/apps/model-page/README.md
+++ b/apps/model-page/README.md
@@ -5,23 +5,23 @@ This is a project that aims to build a simple set of scripts that can be include
 To run the demo first go to root folder of this repository and run `npm i`
 
 then come back to this project and start it
+
 ```
 cd apps/model-page
 npm start
 ```
 
-you must run `npm i` only when you fresly checkout the project or deps change
-
+you must run `npm i` only when you freshly checkout the project or deps change
 
 # if you need to bundle your JSCAD scripts
-To bundle your jscad scripts you can use this sample `esbuild ` command:
+
+To bundle your jscad scripts you can use this sample `esbuild` command:
 
 ```sh
-esbuild .\script.js --bundle --external:@jscad/modeling --outdir=build  
+esbuild .\script.js --bundle --external:@jscad/modeling --outdir=build
 --sourcemap=inline --format=cjs --watch
 ```
 
-This way `@jscad/modeling` will not be included in the bundle, and that is ok because worker has it available unlike other dependencies that you might have. You can drag and drop the generated script on http://openjscad.xyz and develop it even further before including with your HTML page.
+This way `@jscad/modeling` will not be included in the bundle, and that is ok because worker has it available unlike other dependencies that you might have. You can drag and drop the generated script on https://jscad.app and develop it even further before including with your HTML page.
 
 `--sourcemap=inline` option is gives line numbers when errors occur, it is nice while developing, but can be omitted for production build.
-

--- a/apps/model-page/index.html
+++ b/apps/model-page/index.html
@@ -16,7 +16,7 @@
       <div id="root" style="overflow: hidden"></div>
     </div>
     <script type="module">
-      import { initEngine, runFile } from './build/main.js'
+      import { initEngine, runScript } from './build/main.js'
       // you can define bundles that are loaded by the worker and not bundled width a script
       // not bundling @jscad/modeling makes sense as soon as you have more than one script you want to show
       // esbuild howto: to bundle all imports except @jscad/modeling use: --external:@jscad/modeling
@@ -26,8 +26,9 @@
           '@jscad/modeling': document.baseURI+'build/bundle.jscad_modeling.js',
         },
       }
-      await initEngine(THREE, 'root', workerOptions)
-      runFile('jscad/planter.mesh.js')
+      initEngine(THREE, 'root', workerOptions).then(() => {
+        runScript('./jscad/planter.mesh.js')
+      })
     </script>
   </body>
 </html>

--- a/apps/model-page/main.js
+++ b/apps/model-page/main.js
@@ -127,8 +127,9 @@ const paramChangeCallback = params => {
   sendCmd('runMain', { params })
 }
 
-export const runFile = file => {
-  sendCmd('runFile', { file }).then(result => {
+export const runScript = file => {
+  fileToRun = file.replace(/.*\//, '').replace(/\..*/, '')
+  sendCmd('runScript', { url: file }).then(result => {
     console.log('result', result)
     genParams({ target: byId('paramsDiv'), params: result.def || {}, callback: paramChangeCallback })
   })

--- a/apps/model-page/package.json
+++ b/apps/model-page/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "dev-init": "npm-run-all bundle-**",
     "start": "npm run dev-init && esbuild main.js --format=esm --outdir=build --bundle --sourcemap=inline --serve=127.0.0.1:5121 --servedir=.",
-    "build": "npm run dev-init && esbuild main.js --format=esm --outdir=build --bundle --sourcemap=inline"
+    "build": "npm run dev-init && esbuild main.js --format=esm --outdir=build --bundle --sourcemap=inline",
+    "bundle-threejs": "esbuild bundle.threejs.js --outdir=build --bundle --sourcemap --minify --format=iife --global-name=THREE",
+    "bundle-worker": "esbuild bundle.worker.js --outdir=build --bundle --sourcemap --minify --format=iife",
+    "bundle-jscad_modeling": " esbuild bundle.jscad_modeling.js --outdir=build --bundle --sourcemap --minify --format=cjs"
   },
   "dependencies": {
     "@jscad/modeling": "2.11.0",


### PR DESCRIPTION
As we've been evolving the jscadui project with a focus on jscad.app... some of the other apps got broken along the way. Users are still asking about how to host standalone model pages, so it would be good to keep them working.

Most of the breakage was from changing `runFile` to `runScript`.

I also took the liberty of updating the `jscad-examples` app with a new design... it is a parameterized dropdown that let's you select from the other examples.

![jscad-examples](https://github.com/hrgdavor/jscadui/assets/1766297/91a4ba53-1b36-4358-8767-76b7fd41e17f)

I also updated the READMEs, mostly fixing typos and adding some more details.
