### PR TITLE
jscad-web: try to fetch script directly first

### DIFF
--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -206,6 +206,7 @@ remote.init((script) => {
   welcome.dismiss()
 }, (err) => {
   // show remote script error
+  loadDefault = false
   setError(err)
   welcome.dismiss()
 })

--- a/apps/jscad-web/serve.js
+++ b/apps/jscad-web/serve.js
@@ -13,6 +13,7 @@ const mimeTypes = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
   '.svg': 'image/svg+xml',
+  '.txt': 'text/plain',
   '.ttf': 'font/ttf',
   '.woff2': 'font/woff2',
 }

--- a/apps/jscad-web/src/remote.js
+++ b/apps/jscad-web/src/remote.js
@@ -23,11 +23,22 @@ export const loadFromUrl = (compileFn, setError) => async () => {
   }
 }
 
+/**
+ * Try to fetch a url directly, but if that fails (due to CORS)
+ * then fallback to fetching via server proxy
+ */
 const fetchUrl = async (url) => {
-  const res = await fetch(`/remote?url=${url}`)
-  if (res.ok) {
-    return await res.text()
+  // Try to fetch url directly
+  const direct = await fetch(url)
+  if (direct.ok) {
+    return await direct.text()
   } else {
-    throw new Error(`failed to load script from url ${url}`)
+    // failed to fetch directly, try proxy
+    const proxy = await fetch(`/remote?url=${url}`)
+    if (proxy.ok) {
+      return await res.text()
+    } else {
+      throw new Error(`failed to load script from url ${url}`)
+    }
   }
 }

--- a/apps/jscad-web/src/welcome.js
+++ b/apps/jscad-web/src/welcome.js
@@ -18,6 +18,7 @@ export const init = () => {
 }
 
 export const dismiss = (e) => {
+  if (!welcome) return
   // dismiss if click on anything other than a link
   const isClickable = ['A', 'LABEL', 'INPUT'].includes(e?.target?.nodeName)
   if (showing && (!e || !welcome.contains(e.target) || !isClickable)) {


### PR DESCRIPTION
When loading a remote url via link, try to fetch url directly first. Only use the serverside `/remote` endpoint as a fallback to workaround cors when needed.

This makes it easier to test things while running in dev mode, reduces server load, and improves user privacy.

Also fixed small bug where error on url load would disappear when default model loads, and added content type for robots.txt.