### PR TITLE
jscad-web: resizable drawer fixes

### DIFF
--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -100,6 +100,7 @@ document.body.ondragleave = document.body.ondragend = ev => {
 const setError = error => {
   const errorBar = byId('error-bar')
   if (error) {
+    console.error(error)
     const message = formatStacktrace(error).replace(/^Error: /, '')
     const errorMessage = byId('error-message')
     errorMessage.innerText = message

--- a/apps/jscad-web/src/drawer.js
+++ b/apps/jscad-web/src/drawer.js
@@ -38,7 +38,7 @@ export const init = () => {
     isDragging = false
     dragStartX = e.clientX
     dragStartWidth = editor.offsetWidth
-    dragStartTime = new Date()
+    dragStartTime = e.timeStamp
     e.preventDefault()
   })
 
@@ -56,7 +56,7 @@ export const init = () => {
   })
 
   window.addEventListener('pointerup', (e) => {
-    const downTime = new Date() - dragStartTime
+    const downTime = e.timeStamp - dragStartTime
     // Long press, assume dragging
     if (isDragging || downTime > 200) {
       // Prevent click
@@ -64,7 +64,7 @@ export const init = () => {
       // Save width
       const width = editor.offsetWidth
       // Minimum width, otherwise snap to closed
-      if (width > 10) {
+      if (width > 50) {
         localStorage.setItem('editor.width', width)
         localStorage.setItem('editor.closed', false)
       } else {

--- a/apps/jscad-web/src/drawer.js
+++ b/apps/jscad-web/src/drawer.js
@@ -22,6 +22,7 @@ export const init = () => {
 
   toggle.addEventListener('click', () => {
     if (!isDragging) {
+      editor.classList.add('transition') // animate
       const isClosed = editor.classList.contains('closed')
       localStorage.setItem('editor.closed', !isClosed)
       if (isClosed) {
@@ -47,7 +48,7 @@ export const init = () => {
       // Moved more than 5 pixels, assume dragging
       if (isDragging || Math.abs(delta) > 5) {
         isDragging = true
-        editor.classList.add('dragging') // prevent animation
+        editor.classList.remove('transition') // no animation when dragging
         const width = Math.max(0, dragStartWidth - delta)
         setEditorWidth(width)
       }
@@ -55,7 +56,6 @@ export const init = () => {
   })
 
   window.addEventListener('pointerup', (e) => {
-    editor.classList.remove('dragging')
     const downTime = new Date() - dragStartTime
     // Long press, assume dragging
     if (isDragging || downTime > 200) {
@@ -69,15 +69,10 @@ export const init = () => {
         localStorage.setItem('editor.closed', false)
       } else {
         localStorage.setItem('editor.closed', true)
+        editor.classList.add('transition') // snap closed
         setEditorWidth(0)
       }
     }
     isMouseDown = false
   })
-
-  // Close drawer on mobile
-  if (window.innerWidth < 768) {
-    // 'dragging' to prevent animation
-    editor.classList.add('closed', 'dragging')
-  }
 }

--- a/apps/jscad-web/src/drawer.js
+++ b/apps/jscad-web/src/drawer.js
@@ -1,4 +1,3 @@
-
 let isMouseDown = false
 let isDragging = false
 let dragStartX
@@ -7,21 +6,21 @@ let dragStartTime
 
 export const init = () => {
   // Initialize drawer action
-  const editor = document.getElementById("editor")
-  const toggle = document.getElementById("editor-toggle")
+  const editor = document.getElementById('editor')
+  const toggle = document.getElementById('editor-toggle')
+
+  const setEditorWidth = (w) => {
+    if (w) editor.style.width = `${w}px`
+  }
   setEditorWidth(localStorage.getItem('editor.width') || 400)
 
-  function setEditorWidth(w){
-    if(w) editor.style.width = `${w}px`
-  }
-
-  toggle.addEventListener("click", () => {
+  toggle.addEventListener('click', () => {
     if (!isDragging) {
-      editor.classList.toggle("closed")
+      editor.classList.toggle('closed')
     }
   })
 
-  toggle.addEventListener('mousedown', (e) => {
+  toggle.addEventListener('pointerdown', (e) => {
     isMouseDown = true
     isDragging = false
     dragStartX = e.clientX
@@ -30,41 +29,41 @@ export const init = () => {
     e.preventDefault()
   })
 
-  window.addEventListener('mousemove', (e) => {
+  window.addEventListener('pointermove', (e) => {
     if (isMouseDown) {
       const delta = e.clientX - dragStartX
       // Moved more than 5 pixels, assume dragging
       if (isDragging || Math.abs(delta) > 5) {
         isDragging = true
-        editor.classList.add("dragging") // prevent animation
+        editor.classList.add('dragging') // prevent animation
         const width = dragStartWidth - delta
         // Handle open/closed state
         if (width > 0) {
           setEditorWidth(width)
           localStorage.setItem('editor.width', width)
-          editor.classList.remove("closed")
+          editor.classList.remove('closed')
         } else {
           editor.style.width = ''
-          editor.classList.add("closed")
+          editor.classList.add('closed')
         }
       }
     }
   })
 
-  window.addEventListener('mouseup', (e) => {
+  window.addEventListener('pointerup', (e) => {
     const downTime = new Date() - dragStartTime
     // Long press, assume dragging
     if (isDragging || downTime > 200) {
       // Prevent click
       isDragging = true
     }
-    editor.classList.remove("dragging")
+    editor.classList.remove('dragging')
     isMouseDown = false
   })
 
   // Close drawer on mobile
   if (window.innerWidth < 768) {
-    // "dragging" to prevent animation
-    editor.classList.add("closed", "dragging")
+    // 'dragging' to prevent animation
+    editor.classList.add('closed', 'dragging')
   }
 }

--- a/apps/jscad-web/src/editor.js
+++ b/apps/jscad-web/src/editor.js
@@ -50,6 +50,11 @@ export const init = (defaultCode, fn) => {
   // Initialize drawer action
   drawer.init()
 
+  // Make editor hint clickable
+  document.getElementById('editor-hint').addEventListener('click', () => {
+    compile(view.state.doc.toString(), currentFile)
+  })
+
   // Setup file selector
   editorFile.addEventListener('click', (e) => {
     editorNav.classList.toggle('open')

--- a/apps/jscad-web/src/remote.js
+++ b/apps/jscad-web/src/remote.js
@@ -17,7 +17,6 @@ export const loadFromUrl = (compileFn, setError) => async () => {
       const script = await fetchUrl(url)
       compileFn(script, url)
     } catch (err) {
-      console.error('failed to load remote script', err)
       setError(err)
     }
   }
@@ -29,16 +28,13 @@ export const loadFromUrl = (compileFn, setError) => async () => {
  */
 const fetchUrl = async (url) => {
   // Try to fetch url directly
-  const direct = await fetch(url)
-  if (direct.ok) {
-    return await direct.text()
+  const res = await fetch(url).catch((err) => {
+    // Failed to fetch directly, try proxy
+    return fetch(`/remote?url=${url}`)
+  })
+  if (res.ok) {
+    return await res.text()
   } else {
-    // failed to fetch directly, try proxy
-    const proxy = await fetch(`/remote?url=${url}`)
-    if (proxy.ok) {
-      return await res.text()
-    } else {
-      throw new Error(`failed to load script from url ${url}`)
-    }
+    throw new Error(`failed to load script from url ${url}`)
   }
 }

--- a/apps/jscad-web/static/index.html
+++ b/apps/jscad-web/static/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" href="/favicon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="JSCAD is an open source set of modular, browser and command line tools for creating parametric 2D and 3D CAD designs with JavaScript code.">
-    <meta name="keywords" content="jscad, openjscad, javascript, cad, svg, stl, obj, csg, 3mf, 3d-design, 2d-design">
+    <meta name="keywords" content="jscad, openjscad, javascript, typescript, cad, svg, stl, obj, csg, 3mf, 3d-design, 2d-design">
     <link rel="stylesheet" href="main.css">
     <title>JSCAD - JavaScript CAD</title>
   </head>
@@ -68,7 +68,7 @@
             <ul id="editor-files"></ul>
           </nav>
           <div id="editor-container"></div>
-          <div id="editor-hint">Shift-enter to update</div>
+          <a id="editor-hint">Shift-enter to update</a>
         </div>
         <div id="editor-toggle"></div>
       </div>

--- a/apps/jscad-web/static/index.html
+++ b/apps/jscad-web/static/index.html
@@ -107,7 +107,7 @@
       if (localStorage.getItem('welcome.dismissed')) {
         document.getElementById('welcome').remove()
       }
-      if (localStorage.getItem('editor.closed') === 'true') {
+      if (localStorage.getItem('editor.closed') === 'true' || window.innerWidth < 768) {
         document.getElementById('editor').classList.add('closed')
       } else if (localStorage.getItem('editor.width')) {
         const editorWidth = localStorage.getItem('editor.width')

--- a/apps/jscad-web/static/index.html
+++ b/apps/jscad-web/static/index.html
@@ -61,7 +61,7 @@
         </div>
       </div>
 
-      <div id="editor" class="open">
+      <div id="editor">
         <div id="editor-drawer">
           <nav id="editor-nav">
             <button id="editor-file"></button>

--- a/apps/jscad-web/static/index.html
+++ b/apps/jscad-web/static/index.html
@@ -100,12 +100,18 @@
     <div id="dropModal">drop jscad script to execute it</div>
 
     <script>
-      // dark mode asap to avoid flash of light
+      // load visible preferences immediately to prevent flash of content
       if (localStorage.getItem('engine.theme') === 'dark') {
         document.body.classList.add('dark')
       }
       if (localStorage.getItem('welcome.dismissed')) {
         document.getElementById('welcome').remove()
+      }
+      if (localStorage.getItem('editor.closed') === 'true') {
+        document.getElementById('editor').classList.add('closed')
+      } else if (localStorage.getItem('editor.width')) {
+        const editorWidth = localStorage.getItem('editor.width')
+        document.getElementById('editor').style.width = `${editorWidth}px`
       }
     </script>
     <script type="module" src="/main.js"></script>

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -168,12 +168,11 @@ p {
 /* editor style */
 #editor {
   position: relative;
-  transition: width 0.5s;
   width: 400px;
   max-width: calc(100vw - 80px);
 }
-#editor.dragging {
-  transition: none;
+#editor.transition {
+  transition: width 0.5s;
 }
 #editor.closed {
   width: 0px !important;

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -194,14 +194,14 @@ p {
 #editor-hint {
   position: absolute;
   bottom: 10px;
-  right: 10px;
-  color: #bbb;
+  right: calc(min(10px, 100% - 180px)); /* push right when editor is small */
+  color: #66666688;
   white-space: nowrap;
   font-size: 10pt;
   user-select: none;
 }
 .dark #editor-hint {
-  color: #888;
+  color: #dddddd88;
 }
 
 /* editor file navigation */

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -169,6 +169,7 @@ p {
 #editor {
   position: relative;
   transition: width 0.5s;
+  width: 400px;
   max-width: calc(100vw - 80px);
 }
 #editor.dragging {
@@ -312,7 +313,6 @@ p {
   content: "\27E8";
 }
 .cm-editor {
-  min-width: 400px;
   height: 100%;
 }
 .cm-gutters {
@@ -355,7 +355,7 @@ p {
 }
 /* numeric */
 .dark .ͼd {
-  color: #aac281;
+  color: #bbc281;
 }
 /* strings */
 .dark .ͼe {
@@ -644,6 +644,9 @@ p {
   #welcome {
     width: 90%;
     left: 5%;
+  }
+  #editor {
+    width: 0;
   }
   jscadui-gizmo {
     --cube-size: 70px;

--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -89,9 +89,6 @@ jscadui-gizmo {
   --cube-fg-hover: #ccc;
 }
 
-jscadui-gizmo::part(face){
-}
-
 a {
   color: #08d;
   text-decoration: none;
@@ -172,6 +169,7 @@ p {
 #editor {
   position: relative;
   transition: width 0.5s;
+  max-width: calc(100vw - 80px);
 }
 #editor.dragging {
   transition: none;
@@ -300,6 +298,7 @@ p {
   padding: 5px;
   display: flex;
   cursor: col-resize;
+  touch-action: none;
 }
 .dark #editor-toggle {
   background-color: #657;
@@ -645,9 +644,6 @@ p {
   #welcome {
     width: 90%;
     left: 5%;
-  }
-  #editor.open {
-    width: 240px;
   }
   jscadui-gizmo {
     --cube-size: 70px;


### PR DESCRIPTION
This PR was focused on making it so that the resizable editor behavior is optimal.

 - change from `mouseup` to `pointerup` etc. so that mobile can drag to resize
 - save the open/closed state separately from the width
 - if user resizes to less than 10 pixels, snap closed
 - restore open/closed and width in index.html to prevent re-layouts
 - make "shift-enter to update" hint clickable
 - fix remote proxy code from the last PR
