### PR TITLE
Sync select style with input

### DIFF
--- a/apps/jscad-web/static/main.css
+++ b/apps/jscad-web/static/main.css
@@ -470,7 +470,9 @@ p {
   margin-right: 2px;
 }
 #paramsDiv select {
+  border-radius: 3px;
   font-size: 10pt;
+  min-width: 60px;
   padding: 2px 4px;
 }
 #paramsDiv .form-line {


### PR DESCRIPTION
Updated select CSS to have the same border radius and minimum width as input. If needed, the width can become larger.