### PR TITLE
improve-github-issues

### DIFF
--- a/apps/jscad-web/static/index.html
+++ b/apps/jscad-web/static/index.html
@@ -27,8 +27,8 @@
         <ul>
           <li><a href="/docs/tutorial-01_gettingStarted.html" target="_blank">Getting Started</a></li>
           <li><a href="/docs/" target="_blank">API Reference</a></li>
-          <li><a href="https://github.com/hrgdavor/jscadui/issues" target="_blank">GitHub Issues (this app)</a></li>
-          <li><a href="https://github.com/jscad/OpenJSCAD.org" target="_blank">GitHub (JSCAD)</a></li>
+          <li><a href="https://github.com/hrgdavor/jscadui/issues" target="_blank">GitHub (this app)</a> - for issues wth app itself</li>
+          <li><a href="https://github.com/jscad/OpenJSCAD.org" target="_blank">GitHub (JSCAD)</a> - for issues with @jscad/modeling</li>
         </ul>
 
         <label for="welcome-dismiss" class="welcome-dismiss">

--- a/apps/jscad-web/static/index.html
+++ b/apps/jscad-web/static/index.html
@@ -27,7 +27,8 @@
         <ul>
           <li><a href="/docs/tutorial-01_gettingStarted.html" target="_blank">Getting Started</a></li>
           <li><a href="/docs/" target="_blank">API Reference</a></li>
-          <li><a href="https://github.com/jscad/OpenJSCAD.org" target="_blank">GitHub</a></li>
+          <li><a href="https://github.com/hrgdavor/jscadui/issues" target="_blank">GitHub Issues (this app)</a></li>
+          <li><a href="https://github.com/jscad/OpenJSCAD.org" target="_blank">GitHub (JSCAD)</a></li>
         </ul>
 
         <label for="welcome-dismiss" class="welcome-dismiss">
@@ -87,7 +88,8 @@
           <ul>
             <li><a href="https://openjscad.xyz/dokuwiki/doku.php" target="_blank">User Guide</a></li>
             <li><a href="/docs/" target="_blank">API Reference</a></li>
-            <li><a href="https://github.com/jscad/OpenJSCAD.org/issues" target="_blank">GitHub Issues</a></li>
+            <li><a href="https://github.com/hrgdavor/jscadui/issues" target="_blank">GitHub Issues (this app)</a></li>
+            <li><a href="https://github.com/jscad/OpenJSCAD.org/issues" target="_blank">GitHub Issues (JSCAD)</a></li>
             <li><a href="https://openjscad.nodebb.com/" target="_blank">User Group</a></li>
             <li><a href="https://discord.com/invite/AaqGskur93" target="_blank">Discord Community</a></li>
           </ul>


### PR DESCRIPTION
fixes: #55

This PR intends to give users link to jscadui repo along with link to JSCAD issues.

Question is if we can make it clearer which issues are for the jscad.app and which for jscad

bit of text with links on splash screen

![image](https://github.com/hrgdavor/jscadui/assets/2480762/7e0b1727-8cd1-4db3-97f5-8f2bda09335c)
