### PR TITLE
gzip in data: uri

### DIFF
--- a/apps/jscad-web/package.json
+++ b/apps/jscad-web/package.json
@@ -26,7 +26,6 @@
     "@jscadui/worker": "*",
     "codemirror": "^6.0.1",
     "gl-matrix": "^3.4.0",
-    "base64-arraybuffer": "^1.0.2",
     "fflate": "0.8.1",
     "three": "^0.147.0"
   },

--- a/apps/jscad-web/package.json
+++ b/apps/jscad-web/package.json
@@ -26,6 +26,8 @@
     "@jscadui/worker": "*",
     "codemirror": "^6.0.1",
     "gl-matrix": "^3.4.0",
+    "base64-arraybuffer": "^1.0.2",
+    "fflate": "0.8.1",
     "three": "^0.147.0"
   },
   "devDependencies": {

--- a/apps/jscad-web/src/remote.js
+++ b/apps/jscad-web/src/remote.js
@@ -1,3 +1,8 @@
+import {decode} from 'base64-arraybuffer'
+import * as fflate from 'fflate'
+
+const gzipPrefix = 'data:application/gzip;base64,'
+
 export const init = (compileFn, setError) => {
   const load = loadFromUrl(compileFn, setError)
   load() // on load
@@ -23,9 +28,15 @@ export const loadFromUrl = (compileFn, setError) => async () => {
 
 /**
  * Try to fetch a url directly, but if that fails (due to CORS)
- * then fallback to fetching via server proxy
+ * then fallback to fetching via server proxy.
  */
 const fetchUrl = async (url) => {
+  if(url.startsWith(gzipPrefix)){
+    const bytes = decode(url.substring(gzipPrefix.length))
+    const dec = fflate.gunzipSync(new Uint8Array(bytes))
+    return new TextDecoder("utf-8").decode(dec)
+  }
+
   // Try to fetch url directly
   const res = await fetch(url).catch(() => {
     // Failed to fetch directly, try proxy

--- a/apps/jscad-web/src/remote.js
+++ b/apps/jscad-web/src/remote.js
@@ -1,4 +1,3 @@
-import {decode} from 'base64-arraybuffer'
 import * as fflate from 'fflate'
 
 const gzipPrefix = 'data:application/gzip;base64,'
@@ -32,7 +31,7 @@ export const loadFromUrl = (compileFn, setError) => async () => {
  */
 const fetchUrl = async (url) => {
   if(url.startsWith(gzipPrefix)){
-    const bytes = decode(url.substring(gzipPrefix.length))
+    const bytes = base64ToArrayBuffer(url.substring(gzipPrefix.length))
     const dec = fflate.gunzipSync(new Uint8Array(bytes))
     return new TextDecoder("utf-8").decode(dec)
   }
@@ -47,4 +46,13 @@ const fetchUrl = async (url) => {
   } else {
     throw new Error(`failed to load script from url ${url}`)
   }
+}
+
+/**
+ * Converts a Base64 encoded string to an ArrayBuffer.
+ * @param {string} base64 - base64 encoded string
+ * @returns {ArrayBuffer} output ArrayBuffer
+ */
+const base64ToArrayBuffer = (base64) => {
+  return Uint8Array.from(atob(base64), c => c.charCodeAt(0)).buffer
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,7 +169,9 @@
         "@jscadui/scene": "*",
         "@jscadui/transform-babel": "*",
         "@jscadui/worker": "*",
+        "base64-arraybuffer": "^1.0.2",
         "codemirror": "^6.0.1",
+        "fflate": "0.8.1",
         "gl-matrix": "^3.4.0",
         "three": "^0.147.0"
       },
@@ -571,6 +573,11 @@
         "@esbuild/win32-ia32": "0.17.19",
         "@esbuild/win32-x64": "0.17.19"
       }
+    },
+    "apps/jscad-web/node_modules/fflate": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ=="
     },
     "apps/jscad-web/node_modules/three": {
       "version": "0.147.0",
@@ -4370,6 +4377,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/basic-auth": {
@@ -14169,7 +14184,7 @@
     },
     "packages/html-gizmo": {
       "name": "@jscadui/html-gizmo",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "~3.3.0",
@@ -20238,8 +20253,10 @@
         "@jscadui/worker": "*",
         "@jsx6/build": "0.2.0",
         "@trivago/prettier-plugin-sort-imports": "~3.3.0",
+        "base64-arraybuffer": "^1.0.2",
         "codemirror": "^6.0.1",
         "esbuild": "^0.17.11",
+        "fflate": "0.8.1",
         "gl-matrix": "^3.4.0",
         "live-server": "^1.2.2",
         "npm-run-all": "^4.1.5",
@@ -20428,6 +20445,11 @@
             "@esbuild/win32-ia32": "0.17.19",
             "@esbuild/win32-x64": "0.17.19"
           }
+        },
+        "fflate": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+          "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ=="
         },
         "three": {
           "version": "0.147.0"
@@ -22853,6 +22875,11 @@
           "dev": true
         }
       }
+    },
+    "base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
     },
     "basic-auth": {
       "version": "2.0.1",


### PR DESCRIPTION
fixes: #76

here is a sample gzipped script:
`data:application/gzip;base64,H4sICN1FqGUAA3Rlc3QADcrBDkAwDADQu6/YjV3GxUUi8SuLFRXrpl1FIv6dd34xBT3AwZ0TFxkXpblgIhM9UmMfhqJMhuFUZGjqaZfZhzamAAfSWluXGSMWvECc5A3+9LAPqDKYvnvtW33S8ZutYgAAAA==`

for script:
```js
module.exports=function main(){return require('@jscad/modeling').primitives.sphere({radius: 50})}
```

@Hermann-SW  works temporarily here(you may need to hit ctrl+F5) until merged and published to jscad.app

https://3d.hrg.hr/jscad/app1/#data:application/gzip;base64,H4sICN1FqGUAA3Rlc3QADcrBDkAwDADQu6/YjV3GxUUi8SuLFRXrpl1FIv6dd34xBT3AwZ0TFxkXpblgIhM9UmMfhqJMhuFUZGjqaZfZhzamAAfSWluXGSMWvECc5A3+9LAPqDKYvnvtW33S8ZutYgAAAA==


