### PR TITLE
multipart-project-example

### DIFF
--- a/apps/jscad-web/examples/multipart.project.template.js
+++ b/apps/jscad-web/examples/multipart.project.template.js
@@ -1,0 +1,48 @@
+/**
+ * Demonstrates a multipart project with part select input.
+ * 
+ * https://github.com/jscad/OpenJSCAD.org/discussions/1141
+ */
+const jscad = require('@jscad/modeling')
+const {sphere, cube} = jscad.primitives 
+const {translate} = jscad.transforms
+
+// all of the functions that generate parts will see the parameters without declaring them explicitly
+const main = ({//@jscad-params
+  size=10, // {type:'slider'}
+  part,
+}, getParams)=>{
+
+  // UTILITY placeholder for part generator functions
+  const parts = {}
+
+  // CTRL+R in vscode works just fine
+  parts.Sample_Cube = ()=>cube({size})
+
+  parts.Sample_Sphere = ()=>{
+    return sphere({radius:size/2})
+  }
+
+  // parts can easily be combined
+  parts.Assembly = ()=>([
+    // jump to definition in vscode (ALT+click) works
+    parts.Sample_Cube(),
+    translate([size+5,0,0], parts.Sample_Sphere()),
+  ])
+
+  /*********************** UTILITY below is just utility code. do not change **************** */
+
+  // we were called by getParameterDefinitions so we need to provide list of parts
+  if(getParams === true){
+    const values = Object.keys(parts)
+    return {values, initial: values[0]}
+  }
+
+  // make sure we always call one of the functions
+  if(!parts[part]) part = Object.keys(parts)[0]
+  return parts[part]()
+}
+
+const getParameterDefinitions = ()=>[{ name: 'part', caption:'Part', type: 'choice', ...main({}, true)}]
+
+module.exports = {main, getParameterDefinitions}

--- a/apps/jscad-web/src/examples.js
+++ b/apps/jscad-web/src/examples.js
@@ -9,6 +9,7 @@ export const examples = [
   { name: 'Slicer', source: './examples/slicer.example.js' },
   { name: 'Balloons', source: './examples/balloons.example.js' },
   { name: 'Parameter Types', source: './examples/parameters.example.js' },
+  { name: 'Multipart project', source: './examples/multipart.project.template.js' },
   { name: 'Import AMF', source: './examples/AMFImport/index.js' },
   { name: 'Import STL', source: './examples/STLImport/index.js' },
   { name: 'Import SVG', source: './examples/SVGImport/index.js' },


### PR DESCRIPTION
An example I shared on jscad that I think is useful. I use this template for some projects

https://github.com/jscad/OpenJSCAD.org/discussions/1141

it is a nice way for multiple parts to share the same parameter values without needing to declare them in each function.

