### PR TITLE
Convert examples to use JSCAD v2 syntax

### DIFF
--- a/apps/jscad-web/examples/balloons.example.js
+++ b/apps/jscad-web/examples/balloons.example.js
@@ -3,7 +3,7 @@
  * @authors Z3 Dev, Simon Clark
  */
 
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { subtract, union } = jscad.booleans
 const { colorize, hexToRgb } = jscad.colors
 const { extrudeFromSlices, extrudeLinear, slice } = jscad.extrusions
@@ -15,7 +15,7 @@ const { circle, ellipsoid } = jscad.primitives
 const { vectorText } = jscad.text
 const { translate, scale, rotateX, center } = jscad.transforms
 
-export const getParameterDefinitions = () => [
+const getParameterDefinitions = () => [
   { name: 'balloon', type: 'group', caption: 'Balloons' },
   { name: 'isBig', type: 'checkbox', checked: true, initial: '20', caption: 'Big?' },
   { name: 'color', type: 'color', initial: '#ffb431', caption: 'Color?' },
@@ -25,6 +25,19 @@ export const getParameterDefinitions = () => [
   { name: 'birthdate', type: 'date', initial: '', min: '1915-01-01', max: '2030-12-31', caption: 'Birthday?', placeholder: 'YYYY-MM-DD' },
   { name: 'age', type: 'int', initial: 20, min: 1, max: 100, step: 1, caption: 'Age?' }
 ]
+
+const main = (params) => {
+  // use the checkbox to determine the size of the sphere
+  params.bRadius = (params.isBig === true) ? 16 : 10
+  // use the color chooser to determine the color of the sphere
+  params.bColor = hexToRgb(params.color)
+
+  return [
+    createBalloons(params),
+    createSalutation(params.name),
+    createBirthDate(params.birthdate)
+  ]
+}
 
 // Build text by creating the font strokes (2D), then extruding up (3D).
 const text = (message, extrusionHeight, characterLineWidth) => {
@@ -108,15 +121,4 @@ const createBirthDate = (birthDate) => {
   return birthDate3D
 }
 
-export const main = (params) => {
-  // use the checkbox to determine the size of the sphere
-  params.bRadius = (params.isBig === true) ? 16 : 10
-  // use the color chooser to determine the color of the sphere
-  params.bColor = hexToRgb(params.color)
-
-  return [
-    createBalloons(params),
-    createSalutation(params.name),
-    createBirthDate(params.birthdate)
-  ]
-}
+module.exports = { main, getParameterDefinitions }

--- a/apps/jscad-web/examples/extrusions.example.js
+++ b/apps/jscad-web/examples/extrusions.example.js
@@ -2,7 +2,7 @@
  * Demonstrates the types of extrusions, and the variety of objects they can create.
  */
 
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { bezier } = jscad.curves
 const { circle, line, polygon, rectangle, roundedRectangle, star } = jscad.primitives
 const { extrudeLinear, extrudeRotate, extrudeFromSlices, slice } = jscad.extrusions
@@ -10,7 +10,7 @@ const { translate } = jscad.transforms
 const { expand } = jscad.expansions
 const { mat4 } = jscad.maths
 
-export const main = () => {
+function main() {
   const shapes = []
 
   // rounded box
@@ -65,3 +65,5 @@ const extrudeBezier = (height) => {
     }
   }, squareSlice)
 }
+
+module.exports = { main }

--- a/apps/jscad-web/examples/gear.example.js
+++ b/apps/jscad-web/examples/gear.example.js
@@ -3,7 +3,7 @@
  * @authors Joost Nieuwenhuijse, Simon Clark
  */
 
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { cylinder, polygon } = jscad.primitives
 const { rotateZ } = jscad.transforms
 const { extrudeLinear } = jscad.extrusions
@@ -12,7 +12,7 @@ const { vec2 } = jscad.maths
 const { degToRad } = jscad.utils
 
 // Here we define the user editable parameters:
-export const getParameterDefinitions = () => [
+const getParameterDefinitions = () => [
   { name: 'numTeeth', caption: 'Number of teeth:', type: 'int', initial: 10, min: 5, max: 20 },
   { name: 'circularPitch', caption: 'Circular pitch:', type: 'float', initial: 5 },
   { name: 'pressureAngle', caption: 'Pressure angle:', type: 'float', initial: 20 },
@@ -22,7 +22,7 @@ export const getParameterDefinitions = () => [
 ]
 
 // Main entry point; here we construct our solid:
-export const main = (params) => {
+const main = (params) => {
   let gear = involuteGear(
     params.numTeeth,
     params.circularPitch,
@@ -125,3 +125,5 @@ const involuteGear = (numTeeth, circularPitch, pressureAngle, clearance, thickne
 
   return union(rootcircle, allTeeth)
 }
+
+module.exports = { main, getParameterDefinitions }

--- a/apps/jscad-web/examples/hulls.example.js
+++ b/apps/jscad-web/examples/hulls.example.js
@@ -2,13 +2,13 @@
  * Demonstrates Hull and Hull Chain operations in 2D and 3D
  */
 
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { colorize } = jscad.colors
-const { circle, cuboid, rectangle, sphere } = jscad.primitives
+const { circle, rectangle, sphere } = jscad.primitives
 const { translate } = jscad.transforms
 const { hull, hullChain } = jscad.hulls
 
-export const main = (params) => {
+function main() {
   const radius = 1.5
   const segments = 16
 
@@ -29,3 +29,5 @@ export const main = (params) => {
     colorize([0.2, 0.2, 1.0], translate([20, 0, 0], [hull(shapes2d), hull(shapes3d)]))
   ]
 }
+
+module.exports = { main }

--- a/apps/jscad-web/examples/jscad.example.js
+++ b/apps/jscad-web/examples/jscad.example.js
@@ -1,9 +1,9 @@
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { intersect, subtract } = jscad.booleans
 const { colorize } = jscad.colors
 const { cube, sphere } = jscad.primitives
 
-export const main = () => {
+function main() {
   const outer = subtract(
     cube({ size: 10 }),
     sphere({ radius: 6.8 })
@@ -17,3 +17,5 @@ export const main = () => {
     colorize([0.7, 0.7, 0.1], inner),
   ]
 }
+
+module.exports = { main }

--- a/apps/jscad-web/examples/multipart.project.template.js
+++ b/apps/jscad-web/examples/multipart.project.template.js
@@ -4,31 +4,31 @@
  * https://github.com/jscad/OpenJSCAD.org/discussions/1141
  */
 const jscad = require('@jscad/modeling')
-const {sphere, cube} = jscad.primitives 
-const {translate} = jscad.transforms
+const { sphere, cube } = jscad.primitives
+const { translate } = jscad.transforms
 
 // all of the functions that generate parts will see the parameters without declaring them explicitly
 const main = ({//@jscad-params
-  size=10, // {type:'slider'}
+  size = 10, // {type: 'slider'}
   part,
-}, getParams)=>{
+}, getParams) => {
 
   // UTILITY placeholder for part generator functions
   const parts = {}
 
   // CTRL+R in vscode works just fine
-  parts.Sample_Cube = ()=>cube({size})
+  parts.Sample_Cube = () => cube({ size })
 
-  parts.Sample_Sphere = ()=>{
-    return sphere({radius:size/2})
+  parts.Sample_Sphere = () => {
+    return sphere({ radius: size / 2 })
   }
 
   // parts can easily be combined
-  parts.Assembly = ()=>([
+  parts.Assembly = () => [
     // jump to definition in vscode (ALT+click) works
     parts.Sample_Cube(),
-    translate([size+5,0,0], parts.Sample_Sphere()),
-  ])
+    translate([size + 5, 0, 0], parts.Sample_Sphere()),
+  ]
 
   /*********************** UTILITY below is just utility code. do not change **************** */
 
@@ -43,6 +43,8 @@ const main = ({//@jscad-params
   return parts[part]()
 }
 
-const getParameterDefinitions = ()=>[{ name: 'part', caption:'Part', type: 'choice', ...main({}, true)}]
+const getParameterDefinitions = () => [
+  { name: 'part', caption: 'Part', type: 'choice', ...main({}, true)}
+]
 
 module.exports = {main, getParameterDefinitions}

--- a/apps/jscad-web/examples/nuts-and-bolts.example.js
+++ b/apps/jscad-web/examples/nuts-and-bolts.example.js
@@ -3,14 +3,14 @@
  * Demonstrates advanced extrusion using slices to generate screw threads.
  */
 
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { cylinder } = jscad.primitives
 const { subtract, union } = jscad.booleans
 const { colorize } = jscad.colors
 const { extrudeFromSlices, slice } = jscad.extrusions
 const { translate } = jscad.transforms
 
-export const getParameterDefinitions = () => [
+const getParameterDefinitions = () => [
   { name: 'hexWidth', type: 'number', initial: 4, min: 0 },
   { name: 'hexHeight', type: 'number', initial: 3, min: 0 },
   { name: 'threadLength', type: 'number', initial: 12, min: 0 },
@@ -21,7 +21,7 @@ export const getParameterDefinitions = () => [
   { name: 'segments', type: 'int', initial: 16, min: 3 },
 ]
 
-export const main = (params) => {
+const main = (params) => {
   return [
     colorize([0.9, 0.6, 0.2], bolt(params)),
     colorize([0.4, 0.4, 0.4], translate([15, 0, 0], nut(params)))
@@ -92,3 +92,4 @@ const angleDiff = (angle1, angle2) => {
   return diff > Math.PI ? Math.PI * 2 - diff : diff
 }
 
+module.exports = { main, getParameterDefinitions }

--- a/apps/jscad-web/examples/parameters.example.js
+++ b/apps/jscad-web/examples/parameters.example.js
@@ -2,14 +2,14 @@
  * Demonstrate all available parameter types
  */
 
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { colorize, hexToRgb } = jscad.colors
 const { sphere } = jscad.primitives
 
 const values = [3, 4, 5, 6]
 const captions = ['three', 'four', 'five', 'six']
 
-export const getParameterDefinitions = () => [
+const getParameterDefinitions = () => [
   { name: 'group1', type: 'group', caption: 'Group 1: Text Entry' },
   { name: 'text', type: 'text', initial: '', size: 20, maxLength: 20, caption: 'Plain Text:', placeholder: '20 characters' },
   { name: 'int', type: 'int', initial: 20, min: 1, max: 100, step: 1, caption: 'Integer:' },
@@ -30,6 +30,8 @@ export const getParameterDefinitions = () => [
   { name: 'checkbox2', type: 'checkbox', checked: false, caption: 'Optional Checkbox:' }
 ]
 
-export const main = (params) => {
+const main = (params) => {
   return colorize(hexToRgb(params.color), sphere({ radius: params.slider }))
 }
+
+module.exports = { main, getParameterDefinitions }

--- a/apps/jscad-web/examples/primitives.example.js
+++ b/apps/jscad-web/examples/primitives.example.js
@@ -3,12 +3,12 @@
  * Demonstrates the basics of a variety of 2D and 3D primitives
  */
 
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { arc, circle, ellipse, line, polygon, rectangle, roundedRectangle, square, star } = jscad.primitives
 const { cube, cuboid, cylinder, cylinderElliptic, ellipsoid, geodesicSphere, roundedCuboid, roundedCylinder, sphere, torus } = jscad.primitives
 const { translate } = require('@jscad/modeling').transforms
 
-export const main = () => {
+function main() {
   const shapes = [
     arc({ center: [-1, -1], radius: 2, startAngle: 0, endAngle: (Math.PI / 2), makeTangent: false, segments: 32 }),
     line([[1, 1], [-1, -1], [1, -1]]),
@@ -45,3 +45,5 @@ export const main = () => {
   // Arrange primitives in a grid
   return shapes.map((primitive, index) => translate([(index % 5 - 1) * 5, Math.floor(index / 5 - 1) * 5, 0], primitive))
 }
+
+module.exports = { main }

--- a/apps/jscad-web/examples/slicer.example.js
+++ b/apps/jscad-web/examples/slicer.example.js
@@ -2,7 +2,7 @@
  * Slice a geometry object into layers
  */
 
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { colorize } = jscad.colors
 const { intersect } = jscad.booleans
 const { extrudeLinear, project } = jscad.extrusions
@@ -10,11 +10,11 @@ const { measureBoundingBox } = jscad.measurements
 const { cuboid, sphere } = jscad.primitives
 const { translate } = jscad.transforms
 
-export const getParameterDefinitions = () => [
+const getParameterDefinitions = () => [
   { name: 'thicness', type: 'slider', initial: 0.75, min: 0.1, max: 2, step: 0.1, caption: 'Layer thickness:' },
 ]
 
-export const main = ({ thicness }) => {
+const main = ({ thicness }) => {
   const obj = sphere({ radius: 6 })
 
   // calculate bounding box
@@ -43,3 +43,5 @@ export const main = ({ thicness }) => {
 
   return colorize([0.7, 0, 0.1], out)
 }
+
+module.exports = { main, getParameterDefinitions }

--- a/apps/jscad-web/examples/text.example.js
+++ b/apps/jscad-web/examples/text.example.js
@@ -3,7 +3,7 @@
  * @authors Simon Clark
  */
 
-import * as jscad from '@jscad/modeling'
+const jscad = require('@jscad/modeling')
 const { union } = jscad.booleans
 const { extrudeLinear } = jscad.extrusions
 const { hullChain } = jscad.hulls
@@ -11,13 +11,13 @@ const { circle, sphere } = jscad.primitives
 const { vectorText } = jscad.text
 const { scale, translate } = jscad.transforms
 
-export const getParameterDefinitions = () => [
+const getParameterDefinitions = () => [
   { name: 'outline_string', initial: 'Outline', type: 'text', caption: 'Outline Text', size: 30 },
   { name: 'flat_string', initial: 'Flat', type: 'text', caption: 'Flat Text', size: 30 },
   { name: 'round_string', initial: 'Round', type: 'text', caption: 'Round Text', size: 30 }
 ]
 
-export const main = (params) => {
+const main = (params) => {
   const outlineText = buildOutlineText(params.outline_string, 2)
   const flatText = buildFlatText(params.flat_string, 2, 2)
   const roundText = buildRoundText(params.round_string, 2)
@@ -77,3 +77,5 @@ const buildRoundText = (message, p) => {
   const message3D = union(lineSegments)
   return translate([0, -35, 0], message3D)
 }
+
+module.exports = { main, getParameterDefinitions }


### PR DESCRIPTION
Fixes #82 

@Hermann-SW raised a good point: right now the scripts used as examples ONLY work on jscad.app because of the magic of jscadui's import handling. This is especially confusing as we are in transition from V2 with `require` and V3 with ES module `import`.

To be consistent, in this PR I reverted the example scripts to use V2 `require` syntax, which should work in both openjscad.xyz and jscad.app.

At some point, once JSCAD V3 is released, I think we should update the examples to use `import` statements, along with the new "flattened" V3 api. But not yet.
