### PR TITLE
feature-save-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ dist
 build/**
 dist/**
 **/.history
+**/.idea
+

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -244,6 +244,16 @@ engine.init().then(viewer => {
 })
 
 let saveMap = {}
+setInterval(async ()=>{
+  for(let p in saveMap){
+    let handle = saveMap[p]
+    let file = await handle.getFile()
+    if(file.lastModified > handle.lastMod){
+      handle.lastMod = file.lastModified
+      editor.filesChanged([file])
+    }
+  }
+},500)
 
 editor.init(
   defaultCode,
@@ -276,13 +286,14 @@ editor.init(
           },
         ],
       }
-      saveMap[path] = fileHandle = await globalThis.showSaveFilePicker?.(opts)
+      fileHandle = await globalThis.showSaveFilePicker?.(opts)
     }
     if (fileHandle) {
-      saveMap[path] = fileHandle
       const writable = await fileHandle.createWritable()
       await writable.write(script)
       await writable.close()
+      saveMap[path] = fileHandle
+      fileHandle.lastMod = Date.now()+500
     }
   },
   path=>sw?.getFile(path)

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -215,6 +215,8 @@ engine.init().then(viewer => {
   viewState.setEngine(viewer)
 })
 
+const saveMap = {}
+
 editor.init(defaultCode, async (script, path) => {
   if (sw && sw.fileToRun) {
     await addToCache(sw.cache, path, script)
@@ -227,6 +229,29 @@ editor.init(defaultCode, async (script, path) => {
   } else {
     runScript({ script })
   }
+},async (script, path) => {
+  console.log('save file', path)
+  let fileHandle = saveMap[path]
+  if(!fileHandle){
+    const opts = {
+      excludeAcceptAllOption: true,
+      types: [
+        {
+          description: "Javascript",
+          accept: { "application/javascript": [".js"] },
+        },
+      ],
+    }
+    saveMap[path] = fileHandle = await globalThis.showSaveFilePicker?.(opts)
+  }
+  if(fileHandle){
+    saveMap[path] = fileHandle
+    const writable = await fileHandle.createWritable()
+    await writable.write(script)
+    await writable.close()
+    console.log('fileHandle', fileHandle)
+  }
+
 })
 menu.init(loadExample)
 welcome.init()

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -77,6 +77,7 @@ async function initFs() {
   sw.defProjectName = 'jscad'
   sw.onfileschange = files => {
     sendNotify('clearFileCache', { files })
+    editor.filesChanged(files)
     if (sw.fileToRun) runScript({ url: sw.fileToRun, base: sw.base })
   }
   sw.getFile = path => getFile(path, sw)
@@ -282,6 +283,7 @@ editor.init(
       await writable.close()
     }
   },
+  path=>sw?.getFile(path)
 )
 menu.init(loadExample)
 welcome.init()

--- a/apps/jscad-web/src/editor.js
+++ b/apps/jscad-web/src/editor.js
@@ -89,11 +89,18 @@ export const setSource = (source, path = '/index.js') => {
 }
 
 export function filesChanged(files){
+  let file
   files.forEach(async path=>{
     if(path == currentFile){
-      let file = await getFileFn(path)
-      readSource(file, path)
-    } 
+      file = await getFileFn(path)
+      readSource(file, currentFile)
+    }else if(path.name === currentFile){
+      let reader = new FileReader()
+      reader.onloadend = ()=>{
+        setSource(reader.result, currentFile)
+      }
+      reader.readAsText(path)
+    }
   })
 }
 

--- a/apps/jscad-web/src/editor.js
+++ b/apps/jscad-web/src/editor.js
@@ -8,6 +8,7 @@ import * as drawer from './drawer.js'
 let view
 
 let compileFn
+let saveFn
 
 // file selector
 let currentFile = '/index.js'
@@ -22,7 +23,12 @@ const compile = (code, path) => {
   }
 }
 
-export const init = (defaultCode, fn) => {
+const save = (code, path) => {
+  compileFn(code, path)
+  saveFn(code, path)
+}
+
+export const init = (defaultCode, fn, _saveFn) => {
   // by calling document.getElementById here instead outside of init we allow the flow
   // where javascript is included in the page before the tempalte is loaded into the DOM
   // it was causing issue to users trying to replicate the app in Vue, and would likely some others too
@@ -30,6 +36,7 @@ export const init = (defaultCode, fn) => {
   editorFile = document.getElementById('editor-file')
 
   compileFn = fn
+  saveFn = _saveFn
   // Initialize codemirror
   const editorDiv = document.getElementById('editor-container')
   view = new EditorView({
@@ -44,7 +51,7 @@ export const init = (defaultCode, fn) => {
         },
         {
           key: 'Mod-s',
-          run: () => compile(view.state.doc.toString(), currentFile),
+          run: () => save(view.state.doc.toString(), currentFile),
           preventDefault: true,
         },
         ...defaultKeymap,

--- a/apps/jscad-web/src/editor.js
+++ b/apps/jscad-web/src/editor.js
@@ -59,7 +59,7 @@ export const init = (defaultCode, fn, _saveFn) => {
     ],
     parent: editorDiv,
   })
-  setSource(defaultCode)
+  setSource(defaultCode, 'jscad.example.js')
 
   // Initialize drawer action
   drawer.init()
@@ -88,7 +88,7 @@ export const setSource = (source, path = '/index.js') => {
 
 export const setFiles = (files) => {
   const editorFiles = document.getElementById('editor-files')
-  if (files.length === 1) {
+  if (files.length < 2) {
     editorNav.classList.remove('visible')
   } else {
     // Update spinner

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -48,7 +48,9 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
 
     const resolved = resolveUrl(aliasedUrl, base, root, moduleBase)
     const resolvedStr = resolved.url.toString()
-    const isJs = resolvedStr.endsWith('.ts') || resolvedStr.endsWith('.js')
+    const arr = resolvedStr.split('/')
+    // no file ext is usually module from CDN
+    const isJs = !arr[arr.length-1].includes('.') || resolvedStr.endsWith('.ts') || resolvedStr.endsWith('.js')
     if(!isJs && importData){
       const info = extractPathInfo(resolvedStr)
       let content = readFile(resolvedStr,{output: importData.isBinaryExt(info.ext)})


### PR DESCRIPTION
demo: https://3d.hrg.hr/jscad/save/

like mentioned in https://github.com/hrgdavor/jscadui/issues/88#issuecomment-1906776094

feature  to allow `ctrl+s` to save file from editors

basic flow is initally implemented for solo script in the editor, 
- [x] first save opens dialog
- [x] subsequent save saves into the same file

more to do
- [x] change internal file name to the file name that dropped (single file)
- [x] dropped (single file) without save dialog
- [x] provide file name proposal
- [x] reset reference to file name after new script is loaded examples or other source
- [x] reset file entry list when example loaded after folder loaded
- [x] use file handle from drag and drop to save the same file
- [x] change internal file name to the file name that was selected

not caused here
- [x] refresh editor when file is changed on disk (change is seen in render result, but not in editor source)


https://github.com/hrgdavor/jscadui/assets/2480762/31bc8ea9-180d-488f-8c57-694bc8588156

