### PR TITLE
Prepend "use strict" to all 15 examples

### DIFF
--- a/apps/jscad-web/examples/AMFImport/index.js
+++ b/apps/jscad-web/examples/AMFImport/index.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * AMF Import Demonstration
  * @category Imports

--- a/apps/jscad-web/examples/STLImport/index.js
+++ b/apps/jscad-web/examples/STLImport/index.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * STL Import Demonstration
  * @category Imports

--- a/apps/jscad-web/examples/SVGImport/index.js
+++ b/apps/jscad-web/examples/SVGImport/index.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * SVG Import Demonstration
  * @category Imports

--- a/apps/jscad-web/examples/balloons.example.js
+++ b/apps/jscad-web/examples/balloons.example.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * Birthday Balloons with interactive parameters
  * @authors Z3 Dev, Simon Clark

--- a/apps/jscad-web/examples/extrusions.example.js
+++ b/apps/jscad-web/examples/extrusions.example.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * Demonstrates the types of extrusions, and the variety of objects they can create.
  */

--- a/apps/jscad-web/examples/gear.example.js
+++ b/apps/jscad-web/examples/gear.example.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * Build a Parametric Involute Gear as a parametric design.
  * @authors Joost Nieuwenhuijse, Simon Clark

--- a/apps/jscad-web/examples/hulls.example.js
+++ b/apps/jscad-web/examples/hulls.example.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * Demonstrates Hull and Hull Chain operations in 2D and 3D
  */

--- a/apps/jscad-web/examples/jscad.example.js
+++ b/apps/jscad-web/examples/jscad.example.js
@@ -1,3 +1,4 @@
+"use strict"
 const jscad = require('@jscad/modeling')
 const { intersect, subtract } = jscad.booleans
 const { colorize } = jscad.colors

--- a/apps/jscad-web/examples/multipart.project.template.js
+++ b/apps/jscad-web/examples/multipart.project.template.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * Demonstrates a multipart project with part select input.
  * 

--- a/apps/jscad-web/examples/nuts-and-bolts.example.js
+++ b/apps/jscad-web/examples/nuts-and-bolts.example.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * Nuts and Bolts
  * Demonstrates advanced extrusion using slices to generate screw threads.

--- a/apps/jscad-web/examples/parameters.example.js
+++ b/apps/jscad-web/examples/parameters.example.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * Demonstrate all available parameter types
  */

--- a/apps/jscad-web/examples/primitives.example.js
+++ b/apps/jscad-web/examples/primitives.example.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * JSCAD Primitives Demonstration
  * Demonstrates the basics of a variety of 2D and 3D primitives

--- a/apps/jscad-web/examples/slicer.example.js
+++ b/apps/jscad-web/examples/slicer.example.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * Slice a geometry object into layers
  */

--- a/apps/jscad-web/examples/svg.tester.js
+++ b/apps/jscad-web/examples/svg.tester.js
@@ -1,3 +1,4 @@
+"use strict"
 /*
  if you do not see the shape, it couldbe that it is out os view, so zoom out to check
  if you have a single shape svg that is red, it is inverted

--- a/apps/jscad-web/examples/text.example.js
+++ b/apps/jscad-web/examples/text.example.js
@@ -1,3 +1,4 @@
+"use strict"
 /**
  * Demonstrates methods of building 3D text
  * @authors Simon Clark


### PR DESCRIPTION
As discussed on discord.
Only
```
"use strict"
```
without semicolon as many don't like semicolon on discord
