### PR TITLE
Allow reload after changes in imported files

### DIFF
--- a/apps/engine-test/main.js
+++ b/apps/engine-test/main.js
@@ -246,7 +246,7 @@ async function initFs() {
   sw = await registerServiceWorker('bundle.fs-serviceworker.js?prefix=/swfs/')
   sw.defProjectName = 'jscad'
   sw.onfileschange = files => {
-    workerApi.jscadClearFileCache({ files })
+    workerApi.jscadClearFileCache({ files, root: sw.base })
     if (sw.fileToRun) jscadScript({ url: sw.fileToRun, base: sw.base })
   }
 }

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -1,6 +1,7 @@
 import {
   addToCache,
   analyzeProject,
+  clearCache,
   clearFs,
   extractEntries,
   fileDropped,
@@ -121,8 +122,6 @@ document.body.ondrop = async ev => {
     await resetFileRefs()
     if (!sw) await initFs()
     showDrop(false)
-    workerApi.jscadClearTempCache()
-
     await fileDropped(sw, files)
 
    reloadProject()
@@ -134,6 +133,8 @@ document.body.ondrop = async ev => {
 }
 
 async function reloadProject() {
+  workerApi.jscadClearTempCache()
+  clearCache(sw.cache)
   saveMap = {}
   sw.filesToCheck = []
   let { alias, script } = await analyzeProject(sw)

--- a/apps/jscad-web/main.js
+++ b/apps/jscad-web/main.js
@@ -101,7 +101,7 @@ async function initFs() {
     if (files.includes('/package.json')) {
       reloadProject()
     } else {
-      workerApi.jscadClearFileCache({ files })
+      workerApi.jscadClearFileCache({ files, root: sw.base })
       editor.filesChanged(files)
       if (sw.fileToRun) jscadScript({ url: sw.fileToRun, base: sw.base })
     }
@@ -383,7 +383,7 @@ editor.init(
       // it is expected if multiple files require same file/module that first time it is loaded
       // but for others resolved module is returned
       // if not cleared by calling jscadClearFileCache, require will not try to reload the file
-      await workerApi.jscadClearFileCache({ files: [path] })
+      await workerApi.jscadClearFileCache({ files: [path] , root: sw.base})
       if (sw.fileToRun) jscadScript({ url: sw.fileToRun, base: sw.base })
     } else {
       jscadScript({ script })

--- a/packages/fs-provider/fs-provider.js
+++ b/packages/fs-provider/fs-provider.js
@@ -346,7 +346,6 @@ export const checkFiles = async sw => {
     }
 
     // TODO clear sw cache
-    // TODO sendCmd jscadClearFileCache {files}
   }
   requestAnimationFrame(() => checkFiles(sw))
 }

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -45,9 +45,9 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
 
     const resolved = resolveUrl(aliasedUrl, base, root, moduleBase)
     const resolvedStr = resolved.url.toString()
-    const arr = resolvedStr.split('/')
+    const urlComponents = resolvedStr.split('/')
     // no file ext is usually module from CDN
-    const isJs = !arr[arr.length - 1].includes('.') || resolvedStr.endsWith('.ts') || resolvedStr.endsWith('.js')
+    const isJs = !urlComponents[urlComponents.length - 1].includes('.') || resolvedStr.endsWith('.ts') || resolvedStr.endsWith('.js')
     if (!isJs && importData) {
       const info = extractPathInfo(resolvedStr)
       const content = readFile(resolvedStr, { output: importData.isBinaryExt(info.ext) })

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -20,10 +20,7 @@ export { resolveUrl } from './resolveUrl'
 // we need eval to do the same without prefix
 // https://esbuild.github.io/content-types/#direct-eval
 // to be nice to bundlers we need indirect eval
-// also self is not available in nodejs
-export const runModule = (typeof self === 'undefined' ? eval : self.eval)(
-  '(require, exports, module, source)=>eval(source)',
-)
+export const runModule = globalThis.eval('(require, exports, module, source)=>eval(source)')
 
 export const require = (urlOrSource, transform, readFile, base, root, importData = null, moduleBase = MODULE_BASE) => {
   let source

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -132,7 +132,7 @@ const requireModule = (id, url, source, _require) => {
 /**
  * Clear file cache for specific files. Used when a file has changed.
  */
-export const clearFileCache = async ({ files }) => {
+export const clearFileCache = ({ files }) => {
   const cache = requireCache.local
   files.forEach(f => {
     delete cache[f]

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -130,13 +130,24 @@ const requireModule = (id, url, source, _require) => {
 }
 
 /**
- * Clear file cache for specific files. Used when a file has changed.
-* @param {{files:Array<string>}} obj
+ * @typedef ClearFileCacheOptions
+ * @prop {Array<String>} files
+ * @prop {string} root
  */
-export const clearFileCache = ({ files }) => {
+
+/**
+ * Clear file cache for specific files. Used when a file has changed.
+* @param {ClearFileCacheOptions} obj
+ */
+export const clearFileCache = ({ files, root }) => {
   const cache = requireCache.local
-for (const file of   files) {
+for (const file of files) {
     delete cache[file]
+if (root !== undefined) {
+      const path = file.startsWith("/") ? `.${file}` : file;
+      const url = new URL(path, root);
+      delete cache[url.toString()]
+    }
   }
 }
 

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -50,7 +50,7 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
     const isJs = !arr[arr.length - 1].includes('.') || resolvedStr.endsWith('.ts') || resolvedStr.endsWith('.js')
     if (!isJs && importData) {
       const info = extractPathInfo(resolvedStr)
-      let content = readFile(resolvedStr, { output: importData.isBinaryExt(info.ext) })
+      const content = readFile(resolvedStr, { output: importData.isBinaryExt(info.ext) })
       return importData.deserialize(info, content)
     }
 
@@ -90,7 +90,7 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
     }
   }
   if (source !== undefined) {
-    let extension = getExtension(resolvedUrl)
+    const extension = getExtension(resolvedUrl)
     // https://cdn.jsdelivr.net/npm/@jscad/svg-serializer@2.3.13/index.js uses require to read package.json
     if (extension === 'json') {
       exports = JSON.parse(source)
@@ -98,7 +98,7 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
       // do not transform bundles that are already cjs ( requireCache.bundleAlias.*)
       if (transform && !bundleAlias) source = transform(source, resolvedUrl).code
       // construct require function relative to resolvedUrl
-      let requireFunc = newUrl => require(newUrl, transform, readFile, resolvedUrl, root, importData, moduleBase)
+      const requireFunc = newUrl => require(newUrl, transform, readFile, resolvedUrl, root, importData, moduleBase)
       const module = requireModule(url, resolvedUrl, source, requireFunc)
       module.local = isRelativeFile
       exports = module.exports

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -131,6 +131,7 @@ const requireModule = (id, url, source, _require) => {
 
 /**
  * Clear file cache for specific files. Used when a file has changed.
+* @param {{files:Array<string>}} obj
  */
 export const clearFileCache = ({ files }) => {
   const cache = requireCache.local

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -41,7 +41,7 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
 
   if (source === undefined) {
     bundleAlias = requireCache.bundleAlias[url]
-    const aliasedUrl = bundleAlias || requireCache.alias[url] || url
+    const aliasedUrl = bundleAlias ?? requireCache.alias[url] ?? url
 
     const resolved = resolveUrl(aliasedUrl, base, root, moduleBase)
     const resolvedStr = resolved.url.toString()

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -32,9 +32,9 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
   let cache
   let cacheUrl
   let bundleAlias
-  if(typeof urlOrSource === 'string'){
+  if (typeof urlOrSource === 'string') {
     url = urlOrSource
-  }else{
+  } else {
     source = urlOrSource.script
     url = urlOrSource.url
     isRelativeFile = true
@@ -50,10 +50,10 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
     const resolvedStr = resolved.url.toString()
     const arr = resolvedStr.split('/')
     // no file ext is usually module from CDN
-    const isJs = !arr[arr.length-1].includes('.') || resolvedStr.endsWith('.ts') || resolvedStr.endsWith('.js')
-    if(!isJs && importData){
+    const isJs = !arr[arr.length - 1].includes('.') || resolvedStr.endsWith('.ts') || resolvedStr.endsWith('.js')
+    if (!isJs && importData) {
       const info = extractPathInfo(resolvedStr)
-      let content = readFile(resolvedStr,{output: importData.isBinaryExt(info.ext)})
+      let content = readFile(resolvedStr, { output: importData.isBinaryExt(info.ext) })
       return importData.deserialize(info, content)
     }
 
@@ -61,7 +61,7 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
     resolvedUrl = resolved.url
     cacheUrl = resolved.url
 
-    cache = requireCache[isRelativeFile ? 'local':'module']
+    cache = requireCache[isRelativeFile ? 'local' : 'module']
     exports = cache[cacheUrl] // get from cache
     if (!exports) {
       // not cached
@@ -72,8 +72,8 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
           const srch = ' * Original file: '
           let idx = source.indexOf(srch)
           if (idx != -1) {
-            const idx2 = source.indexOf('\n', idx+srch.length+1)
-            const realFile = new URL(source.substring(idx+srch.length, idx2), resolvedUrl).toString()
+            const idx2 = source.indexOf('\n', idx + srch.length + 1)
+            const realFile = new URL(source.substring(idx + srch.length, idx2), resolvedUrl).toString()
             resolvedUrl = base = realFile
           }
         }
@@ -109,7 +109,7 @@ export const require = (urlOrSource, transform, readFile, base, root, importData
       // will be effectively transformed to 
       // const jscad = require('@jscad/modeling').default
       // we need to plug-in default if missing
-      if(!('default' in exports)) exports.default = exports
+      if (!('default' in exports)) exports.default = exports
     }
   }
 
@@ -135,9 +135,9 @@ const requireModule = (id, url, source, _require) => {
 /**
  * Clear file cache for specific files. Used when a file has changed.
  */
-export const clearFileCache = async ({files}) => {
+export const clearFileCache = async ({ files }) => {
   const cache = requireCache.local
-  files.forEach(f=>{
+  files.forEach(f => {
     delete cache[f]
   })
 }

--- a/packages/require/src/require.js
+++ b/packages/require/src/require.js
@@ -135,9 +135,9 @@ const requireModule = (id, url, source, _require) => {
  */
 export const clearFileCache = ({ files }) => {
   const cache = requireCache.local
-  files.forEach(f => {
-    delete cache[f]
-  })
+for (const file of   files) {
+    delete cache[file]
+  }
 }
 
 /**

--- a/packages/worker/worker.js
+++ b/packages/worker/worker.js
@@ -21,8 +21,7 @@ import { extractPathInfo, readAsArrayBuffer, readAsText } from '../fs-provider/f
  @typedef ExportDataOptions
  @prop {string} format
 
- @typedef ClearFileCacheOptions
- @prop {Array<String>} files
+@typedef {import('@jscadui/require').ClearFileCacheOptions} ClearFileCacheOptions
 
  @typedef RunMainOptions
  @prop {Object} params


### PR DESCRIPTION
This changes do several things:

1. Fix the cache clearing after modifications in imported files. The fs-provider uses the file path. The cache uses the URL. I have added some logic to generate the URL from the path. This URL can then be used to clear the cache.
2. Implement logic for clearing the cache in indirectly imported files. The new Map requireCache.knownDependencies contains a list of all files that are imported for a specific file. This information is used to recursively clear the caches of other modules when one of its dependencies has changed.
3. Add more JSDoc Type annotations
4. Some minor syntax cleanups (let => const, || => ??, self=>globalThis, ...)

This updates for changes in the main file are still broken due to a bug in a prior commit.