### PR TITLE
Add support for script file drag-and-drop with Safari.

### DIFF
--- a/packages/fs-provider/fs-provider.js
+++ b/packages/fs-provider/fs-provider.js
@@ -2,6 +2,7 @@ import { messageProxy } from '@jscadui/postmessage'
 
 import { toFSEntry, entryCheckPromise } from './src/FSEntry.js'
 import { readAsArrayBuffer, readAsText } from './src/FileReader.js'
+import { safariGetAsHandle } from './src/safariFileHandles.js'
 
 /**
  * @typedef {import('./src/FSEntry.js').FSEntry} FSEntry
@@ -268,7 +269,13 @@ export const extractEntries = async dt => {
     // If dropped items aren't files or directories, reject them
     // Directories also have kind === 'file'
     if (item.kind === 'file') {
-      const handle = await item.getAsFileSystemHandle()
+      var handle
+      try {
+        handle = await item.getAsFileSystemHandle()
+      }
+      catch {
+        handle = await safariGetAsHandle(item)
+      }
       const fsEntry = toFSEntry(handle, root)
       fsEntries.push(fsEntry)
     }

--- a/packages/fs-provider/src/safariFileHandles.js
+++ b/packages/fs-provider/src/safariFileHandles.js
@@ -1,0 +1,52 @@
+
+async function handleFromEntry(entry)
+{
+  const handle = {
+      name: entry.name,
+      kind: entry.isFile      ? 'file' :
+            entry.isDirectory ? 'directory' :
+                                'unknown',
+    }
+
+  if (handle.kind === 'file') {
+    handle.getFile = () => new Promise((resolve, reject) =>
+      entry.file(resolve, reject))
+  }
+  else if (handle.kind === 'directory') {
+    handle.values = async function* () {
+        const reader = entry.createReader()
+        while (true) {
+          const entries = await new Promise((resolve, reject) =>
+            reader.readEntries(resolve, reject))
+          if (!entries.length) {
+            break
+          }
+          for (const e of entries) {
+            try {
+              yield await handleFromEntry(e)
+            }
+            catch {
+              continue
+            }
+          }
+        }
+      }
+  }
+  else {
+    throw new TypeError('Entry must be file or directory')
+  }
+
+  return handle
+}
+
+
+/**
+ *
+ * @param {DataTransferItem} dti
+ * @returns {Promise<FileSystemHandle>}
+ */
+export async function safariGetAsHandle(dti)
+{
+  return handleFromEntry(dti.webkitGetAsEntry())
+}
+


### PR DESCRIPTION
Safari does not (yet?) support the getAsFileSystemHandle() interface of DataTransferItem.  Here we provide a shim, safariGetAsHandle(), that uses webkitGetAsEntry() to provide an object that looks enough like a FileSystemHandle to satisfy jscadui's fs-provider.